### PR TITLE
#2 Conan package support

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Conan recipe package for BehaviorTree.CPP
+"""
+from conans import ConanFile, CMake, tools
+
+
+class BehaviorTreeConan(ConanFile):
+    name = "BehaviorTree.CPP"
+    license = "MIT"
+    url = "https://github.com/BehaviorTree/BehaviorTree.CPP"
+    author = "Davide Faconti <davide.faconti@gmail.com>"
+    topics = ("conan", "behaviortree", "ai", "robotics", "games", "coordination")
+    description = "This C++ library provides a framework to create BehaviorTrees. It was designed to be flexible, easy to use and fast."
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False], "zmq": [True, False]}
+    default_options = {"shared": False, "zmq": True}
+    generators = "cmake"
+    exports = "LICENSE"
+    exports_sources = ("cmake/*", "include/*", "src/*", "3rdparty/*", "CMakeLists.txt")
+
+    def requirements(self):
+        """Install ZMQ when required
+        """
+        if self.options.zmq:
+            self.requires("cppzmq/4.3.0@bincrafters/stable")
+
+    def _configure_cmake(self):
+        """Create CMake instance and execute configure step
+        """
+        cmake = CMake(self)
+        cmake.definitions["BUILD_EXAMPLES"] = False
+        cmake.definitions["BUILD_UNIT_TESTS"] = False
+        cmake.configure()
+        return cmake
+
+    def build(self):
+        """Configure, build and install BehaviorTree using CMake.
+        """
+        tools.replace_in_file("CMakeLists.txt",
+                              "project(behaviortree_cpp)",
+                              """project(behaviortree_cpp)
+                              include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+                              conan_basic_setup()""")
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        """Copy BehaviorTree artifacts to package folder
+        """
+        self.copy(pattern="LICENSE", dst="licenses")
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        """Collect built libraries names and solve pthread path.
+        """
+        self.cpp_info.libs = tools.collect_libs(self)
+        if self.settings.os == "Linux":
+            self.cpp_info.libs.append("pthread")


### PR DESCRIPTION
Hi!

This PR is related to issue #2 

Here I added the complete Conan recipe to build BehaviorTreeCPP. The recipe has some attributes, including options (shared and zmq support) and some functions to build your project.

Conan provides an excellent [CMake integration](https://docs.conan.io/en/latest/integrations/cmake.html). As you can see, both examples and tests are disabled when creating the package. Also, there is a little patch on line [41](https://github.com/BehaviorTree/BehaviorTree.CPP/compare/master...uilianries:conanio?expand=1#diff-2b1d42f71f22b7ea0412d7602dec166fR41) where Conan is included in your cmake file. The patch is needed to solve ZMQ and cmake definitions, as `BUILD_SHARED_LIBS` when the option `shared` is True.

To build this project using Conan:

    $ pip install conan
    $ cd BehaviorTree.CPP/
    $ conan create . BehaviorTree.CPP/<version>@BehaviorTree/stable

The command [conan create](https://docs.conan.io/en/latest/reference/commands/creator/create.html) will copy all files listed by `exports_sources` to build directory and will execute all cmake steps, including configure, build and install. The requirement ZMQ C++ will be resolved by Conan automatically. There is the option `zmq` to exclude it as a dependency when requested. By default, will produce BehaviorTree.CPP as static library and linking cppzmq. Your project folder will not be changed by Conan after to build.

To build BehaviorTree.CPP as shared library and standalone (without zmq):

    $ conan create . BehaviorTree.CPP/<version>@BehaviorTree/stable -o BehaviorTree.CPP:shared=True -o BehaviorTree.CPP:zmq=False

The [package reference](https://docs.conan.io/en/latest/faq/using.html#is-there-any-recommendation-regarding-which-user-or-channel-to-use-in-a-reference) `BehaviorTree.CPP/<version>@BehaviorTree/stable` is just a suggestion. You can rename as you prefer.

This PR is the first one of two. After to accept (or not) this PR, I'll create a new one to introduce Conan in your CI (travis and appveyor) to distribute BehaviorTree.CPP as Conan package (recipe and pre-built packages) on [Bintray](https://docs.conan.io/en/latest/uploading_packages/using_bintray.html)

Adding Conan experts to review this PR together:
/cc @memsharded @danimtb @SSE4

closes #2 

Regards!