### PR TITLE
Crash fixed

### DIFF
--- a/include/behaviortree_cpp/xml_parsing.h
+++ b/include/behaviortree_cpp/xml_parsing.h
@@ -37,9 +37,23 @@ struct Tree
 {
     TreeNode* root_node;
     std::vector<TreeNode::Ptr> nodes;
+
+    Tree() : root_node(nullptr)
+    {
+        
+    }
+
+    Tree(TreeNode* root_node, std::vector<TreeNode::Ptr> nodes)
+        : root_node(root_node), nodes(nodes)
+    {
+
+    }
+
     ~Tree()
     {
-        haltAllActions(root_node);
+        if (root_node) {
+            haltAllActions(root_node);
+        }
     }
 };
 

--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -543,7 +543,7 @@ Tree buildTreeFromText(const BehaviorTreeFactory& factory, const std::string& te
     std::vector<TreeNode::Ptr> nodes;
     auto root = parser.instantiateTree(nodes);
     assignBlackboardToEntireTree(root.get(), blackboard);
-    return {root.get(), nodes};
+    return Tree(root.get(), nodes);
 }
 
 Tree buildTreeFromFile(const BehaviorTreeFactory& factory, const std::string& filename,
@@ -555,6 +555,6 @@ Tree buildTreeFromFile(const BehaviorTreeFactory& factory, const std::string& fi
     std::vector<TreeNode::Ptr> nodes;
     auto root = parser.instantiateTree(nodes);
     assignBlackboardToEntireTree(root.get(), blackboard);
-    return {root.get(), nodes};
+    return Tree(root.get(), nodes);
 }
 }


### PR DESCRIPTION
Fixed a crash occuring when you have a Tree structure instantiated but never constructed, the destructor would then try to halt all actions but since `root_node` has never been initialized, it would just segfault.

edit: Didn't notice you used aggregate for the Tree struct, any reason you did that ? I first thought it was for some sort of C compatilibity but since the rest of the library does not use POD-classes, I guess it's not the reason