### PR TITLE
Add test dependency on ament_cmake_gtest.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,8 @@
   <build_depend>libzmq3-dev</build_depend>
   <run_depend>libzmq3-dev</run_depend>
 
+  <test_depend>ament_cmake_gest</test_depend>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Should resolve the failure to build on the ROS buildfarm when ament_cmake is installed but ament_cmake_gtest isn't because it isn't declared.