### PR TITLE
Fix typo in package name.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,6 @@ endif()
 find_package(ament_cmake QUIET)
 
 if ( ament_cmake_FOUND )
-  find_package(ament_cmake_gtest REQUIRED)
-
   # Not adding -DUSING_ROS since xml_parsing.cpp hasn't been ported to ROS2
 
   message(STATUS "------------------------------------------")

--- a/package.xml
+++ b/package.xml
@@ -16,7 +16,7 @@
   <build_depend>libzmq3-dev</build_depend>
   <run_depend>libzmq3-dev</run_depend>
 
-  <test_depend>ament_cmake_gest</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <export>


### PR DESCRIPTION
My original PR had a typo in the package name. With https://github.com/ros2/rosdistro/pull/373 this PR should get tested on the ROS 2 buildfarm if hooks are set up (which they might not be).