### PR TITLE
If backward_ros is present, use it to avoid duplicate symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,12 @@ elseif( CATKIN_DEVEL_PREFIX OR CATKIN_BUILD_BINARY_PACKAGE)
   list(APPEND BEHAVIOR_TREE_EXTERNAL_LIBRARIES ${catkin_LIBRARIES})
   set(BUILD_TOOL_INCLUDE_DIRS ${catkin_INCLUDE_DIRS})
 
+  find_package(backward_ros QUIET)
+  if (backward_ros_FOUND)
+      message(STATUS "backward_ros found, using it.")
+      list(APPEND BEHAVIOR_TREE_EXTERNAL_LIBRARIES ${catkin_LIBRARIES} ${backward_ros_LIBRARIES})
+  endif()
+
 else()
     find_package(GTest)
 
@@ -124,8 +130,11 @@ list(APPEND BT_SOURCE
 
     3rdparty/tinyXML2/tinyxml2.cpp
     3rdparty/minitrace/minitrace.cpp
-    3rdparty/backward-cpp/backward.cpp
     )
+if (NOT backward_ros_FOUND)
+    list(APPEND BT_SOURCE
+        3rdparty/backward-cpp/backward.cpp)
+endif()
 
 ######################################################
 


### PR DESCRIPTION
If BT is linked against a package that also uses backward, it will segfault with:
```
==10381== Invalid free() / delete / delete[] / realloc()
==10381==    at 0x4C2EDEB: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==10381==    by 0x853B369: __cxa_finalize (cxa_finalize.c:56)
==10381==    by 0x5DE6312: ??? (in /home/victor/other_ws/grasping_pipeline_minimal/devel/.private/behaviortree_cpp/lib/libbehaviortree_cpp.so)
==10381==    by 0x4010DE6: _dl_fini (dl-fini.c:235)
==10381==    by 0x853AFF7: __run_exit_handlers (exit.c:82)
==10381==    by 0x853B044: exit (exit.c:104)
==10381==    by 0x8521836: (below main) (libc-start.c:325)
==10381==  Address 0x22c50040 is 0 bytes inside a block of size 8,388,608 free'd
==10381==    at 0x4C2EDEB: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==10381==    by 0x853B369: __cxa_finalize (cxa_finalize.c:56)
==10381==    by 0x4E3E982: ??? (in /opt/pal/erbium/lib/libbackward.so)
==10381==    by 0x4010DE6: _dl_fini (dl-fini.c:235)
==10381==    by 0x853AFF7: __run_exit_handlers (exit.c:82)
==10381==    by 0x853B044: exit (exit.c:104)
==10381==    by 0x8521836: (below main) (libc-start.c:325)
==10381==  Block was alloc'd at
==10381==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==10381==    by 0x4E3F854: backward::SignalHandling::SignalHandling(std::vector<int, std::allocator<int> > const&) (in /opt/pal/erbium/lib/libbackward.so)
==10381==    by 0x4E3E884: ??? (in /opt/pal/erbium/lib/libbackward.so)
==10381==    by 0x40106B9: call_init.part.0 (dl-init.c:72)
==10381==    by 0x40107CA: call_init (dl-init.c:30)
==10381==    by 0x40107CA: _dl_init (dl-init.c:120)
==10381==    by 0x4000C69: ??? (in /lib/x86_64-linux-gnu/ld-2.23.so)
==10381==    by 0x5: ???
==10381==    by 0xFFEFFEF4A: ???
==10381==    by 0xFFEFFEFB0: ???
==10381==    by 0xFFEFFF022: ???
==10381==    by 0xFFEFFF029: ???
==10381==    by 0xFFEFFF04C: ???
==10381== 
```

In ROS we have backward_ros, which can be reused among several packages and avoids this issue.
I don't know if you want to tackle this in a different way, but for backward_ros interactions this is sufficient.