### PR TITLE
Added return NodeStatus::RUNNING to parallel node

### DIFF
--- a/src/controls/parallel_node.cpp
+++ b/src/controls/parallel_node.cpp
@@ -106,8 +106,8 @@ NodeStatus ParallelNode::tick()
 
             case NodeStatus::RUNNING:
             {
-                // do nothing
-            }  break;
+                return NodeStatus::RUNNING;
+            } break;
 
             default:
             {


### PR DESCRIPTION
Fixes #85 
With this change, the parallel node returns running as well instead of ticking its next child.