### PR TITLE
use package format 2

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>behaviortree_cpp_v3</name>
   <version>3.0.7</version>
   <description>
@@ -14,7 +14,7 @@
 
 
   <build_depend>libzmq3-dev</build_depend>
-  <run_depend>libzmq3-dev</run_depend>
+  <exec_depend>libzmq3-dev</exec_depend>
 
 
   <test_depend>ament_cmake_gtest</test_depend>


### PR DESCRIPTION
First, ROS 2 doesn't support format 1.

Also in format 2 the semantic of `test_depend` has been changed (see http://www.ros.org/reps/rep-0140.html#making-test-depend-easier-to-use) which should resolve the current problem in the `dev` job: http://build.ros2.org/view/Ddev/job/Ddev__behaviortree_cpp_v3__ubuntu_bionic_amd64/2/ (which is using the `ros2-dev` branch already.