### PR TITLE
remove redundant find_package call not conditional on BUILD_TESTING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,8 +51,6 @@ endif()
 find_package(ament_cmake QUIET)
 
 if ( ament_cmake_FOUND )
-    find_package(ament_cmake_gtest REQUIRED)
-
     # Not adding -DUSING_ROS since xml_parsing.cpp hasn't been ported to ROS2
 
     message(STATUS "------------------------------------------")


### PR DESCRIPTION
Follow up of #99.

The same is already present here: https://github.com/BehaviorTree/BehaviorTree.CPP/blob/1a2d1479171b46fc8e4b32fb196050261233f9ee/tests/CMakeLists.txt#L23

And the second case is also correctly guarded by a `if(BUILD_TESTING)` check which the removed duplicate lacks.