### PR TITLE
(3dparty coroutine) ifdef MSV_VER to WIN32

### DIFF
--- a/3rdparty/coroutine/coroutine.h
+++ b/3rdparty/coroutine/coroutine.h
@@ -38,7 +38,7 @@
 using ::std::string;
 using ::std::wstring;
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <Windows.h>
 #else
 #if defined(__APPLE__) && defined(__MACH__)
@@ -60,7 +60,7 @@ enum class ResumeResult
     YIELD = 0
 };
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 
 struct Routine
 {


### PR DESCRIPTION
On Windows not only MSVC compilator.