### PR TITLE
Add macOS support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if( ZMQ_FOUND )
     message(STATUS "ZeroMQ found.")
     add_definitions( -DZMQ_FOUND )
     list(APPEND BT_SOURCE src/loggers/bt_zmq_publisher.cpp)
-    list(APPEND BEHAVIOR_TREE_EXTERNAL_LIBRARIES zmq)
+    list(APPEND BEHAVIOR_TREE_EXTERNAL_LIBRARIES ${ZMQ_LIBRARIES})
 else()
     message(WARNING "ZeroMQ NOT found. Skipping the build of [PublisherZMQ] and [bt_recorder].")
 endif()
@@ -174,6 +174,10 @@ if (WIN32)
     add_library(${BEHAVIOR_TREE_LIBRARY} STATIC ${BT_SOURCE} )
 endif()
 
+if( ZMQ_FOUND )
+    list(APPEND BUILD_TOOL_INCLUDE_DIRS ${ZMQ_INCLUDE_DIRS})
+endif()
+
 target_link_libraries(${BEHAVIOR_TREE_LIBRARY} PUBLIC
     ${BEHAVIOR_TREE_EXTERNAL_LIBRARIES})
 
@@ -233,5 +237,3 @@ if( BUILD_EXAMPLES )
     add_subdirectory(sample_nodes)
     add_subdirectory(examples)
 endif()
-
-

--- a/include/behaviortree_cpp_v3/bt_factory.h
+++ b/include/behaviortree_cpp_v3/bt_factory.h
@@ -52,7 +52,7 @@ See examples for more information about configuring CMake correctly
 
 #else
 
-#ifdef __linux__
+#if defined(__linux__) || defined __APPLE__
 
 #define BT_REGISTER_NODES(factory)                                                                 \
     extern "C" void __attribute__((visibility("default")))                                         \

--- a/src/basic_types.cpp
+++ b/src/basic_types.cpp
@@ -124,10 +124,10 @@ double convertFromString<double>(StringView str)
     // see issue #120
     // http://quick-bench.com/DWaXRWnxtxvwIMvZy2DxVPEKJnE
 
-    const auto old_locale = std::setlocale(LC_NUMERIC,nullptr);
-    std::setlocale(LC_NUMERIC,"C");
+    const auto old_locale = setlocale(LC_NUMERIC,nullptr);
+    setlocale(LC_NUMERIC,"C");
     double val = std::stod(str.data());
-    std::setlocale(LC_NUMERIC,old_locale);
+    setlocale(LC_NUMERIC,old_locale);
     return val;
 }
 


### PR DESCRIPTION
Allows to compile on macOS (including latest Catalina)
- Use `ZMQ_LIBRARIES` and `ZMQ_INCLUDE_DIRS` with cmake
- define `BT_REGISTER_NODES` macro
- Replacing `std::setlocale` with `setlocale`