### PR TITLE
Fixed VS2017/2019 compile error

### DIFF
--- a/src/basic_types.cpp
+++ b/src/basic_types.cpp
@@ -1,6 +1,7 @@
 #include "behaviortree_cpp_v3/basic_types.h"
 #include <cstdlib>
 #include <cstring>
+#include <clocale>
 
 namespace BT
 {


### PR DESCRIPTION
Added missing include for std::setlocale. This fixes the following error in Visual Studio:

https://ci.appveyor.com/project/facontidavide59577/behaviortree-cpp/build/job/d1ttd2w84nvnqo2e#L52