### PR TITLE
Added BUILD_SHARED_LIBS option to cmake. If set to "OFF", static libr…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CONFIG_PATH}")
 option(BUILD_EXAMPLES   "Build tutorials and examples" ON)
 option(BUILD_UNIT_TESTS "Build the unit tests" ON)
 option(BUILD_TOOLS "Build commandline tools" ON)
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 #############################################################
 # Find packages
@@ -85,7 +86,7 @@ elseif( CATKIN_DEVEL_PREFIX OR CATKIN_BUILD_BINARY_PACKAGE)
     list(APPEND BEHAVIOR_TREE_EXTERNAL_LIBRARIES ${catkin_LIBRARIES})
     set(BUILD_TOOL_INCLUDE_DIRS ${catkin_INCLUDE_DIRS})
 
-else()
+elseif(BUILD_UNIT_TESTS)
     find_package(GTest)
 
     if(NOT GTEST_FOUND)
@@ -166,7 +167,11 @@ list(APPEND BT_SOURCE
 
 if (UNIX)
     list(APPEND BT_SOURCE src/shared_library_UNIX.cpp )
-    add_library(${BEHAVIOR_TREE_LIBRARY} SHARED ${BT_SOURCE} )
+    if (BUILD_SHARED_LIBS)
+        add_library(${BEHAVIOR_TREE_LIBRARY} SHARED ${BT_SOURCE})
+    else()
+        add_library(${BEHAVIOR_TREE_LIBRARY} STATIC ${BT_SOURCE})
+    endif()
 endif()
 
 if (WIN32)
@@ -203,7 +208,9 @@ endif()
 
 ######################################################
 # Test
-add_subdirectory(tests)
+if (BUILD_UNIT_TESTS)
+    add_subdirectory(tests)
+endif()
 
 ######################################################
 # INSTALL


### PR DESCRIPTION
…ary will be generated

for a UNIX build
If BUILD_UNIT_TESTS is off, do not search for gtest library, and do not include tests subdirectory