### PR TITLE
add unittest switch factory

### DIFF
--- a/tests/src/action_test_node.cpp
+++ b/tests/src/action_test_node.cpp
@@ -40,7 +40,11 @@ BT::NodeStatus BT::AsyncActionTest::tick()
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 
-    stop_loop_ = false;
+    if(stop_loop_)
+    {
+        stop_loop_ = false;
+        return NodeStatus::IDLE;
+    }
     return expected_result_;
 }
 


### PR DESCRIPTION
Please take a look at this new test, I think it is an issue:
[SwitchAfterActionSucceed](https://github.com/BehaviorTree/BehaviorTree.CPP/compare/master...renan028:add_unittest_switch_factory?expand=1#diff-37eef41790bafe1a136803e112aa0f49R240)
The idea is that the switch should first verify if a child finished, before switching. What do you think?

I have tried to fix this way:
[SwitchNode check child first](https://github.com/BehaviorTree/BehaviorTree.CPP/compare/master...renan028:fix_switch_after_child_succeed?expand=1#diff-d2000d0b54f380abfc4861a2c49bd96aR102)

If you think it is correct, I will push.