### PR TITLE
A couple of small changes needed to build on MSVC2015

### DIFF
--- a/include/behaviortree_cpp_v3/utils/make_unique.hpp
+++ b/include/behaviortree_cpp_v3/utils/make_unique.hpp
@@ -2,7 +2,7 @@
 
 #include <memory>
 
-#if defined(_MSC_VER) && __cplusplus == 201103L
+#if defined(_MSC_VER) && _MSC_VER >= 1900 // MSVC 2015 or newer.
 #  define MAKE_UNIQUE_DEFINED 1
 #endif
 

--- a/include/behaviortree_cpp_v3/utils/string_view.hpp
+++ b/include/behaviortree_cpp_v3/utils/string_view.hpp
@@ -892,6 +892,14 @@ nssv_constexpr bool operator== (
 { return lhs.compare( rhs ) == 0 ; }
 
 template< class CharT, class Traits >
+nssv_constexpr bool operator== (
+    basic_string_view <CharT, Traits> lhs,
+    CharT const * rhs) nssv_noexcept
+{
+    return lhs.compare(rhs) == 0;
+}
+
+template< class CharT, class Traits >
 nssv_constexpr bool operator!= (
     basic_string_view <CharT, Traits> lhs,
     basic_string_view <CharT, Traits> rhs ) nssv_noexcept


### PR DESCRIPTION
I needed these two changes to build the library on Visual C++ 2015. Using (a recent enough version of) MSVC2017 you don't need them. However, the library is quite interesting for game developers and many of us are still on old versions.