### PR TITLE
Disable "unreachable code" warning in xml parsing.

### DIFF
--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -20,6 +20,7 @@
 
 #ifdef _MSC_VER
 #pragma warning(disable : 4996) // do not complain about sprintf
+#pragma warning(disable : 4702) // Unreachable code in "SubTree" handling.
 #endif
 
 #include "behaviortree_cpp_v3/xml_parsing.h"
@@ -328,7 +329,8 @@ void VerifyXML(const std::string& xml_text,
                 {
                    ThrowError(node->GetLineNum(), "<remap> was deprecated");
                 }
-                else{
+                else
+				{
                     ThrowError(node->GetLineNum(), "<SubTree> should not have any child");
                 }
             }


### PR DESCRIPTION
The for loop on line 325 in xml_parsing.cpp emits a-warning-as-error "unreachable code detected", when building on MSVC in release mode. Because the body of the loop always throws an error the increment-part of the for loop is never executed. Maybe you want to change this to not use a loop in the future, but this way we can build at least. Tested on MSVC 2015.