### PR TITLE
Fix catkin build for v3

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,7 @@
   <depend>libzmq3-dev</depend>
 
   <export>
+      <build_type condition="$ROS_VERSION == 1">catkin</build_type>
       <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
   </export>
 


### PR DESCRIPTION
This allows the v3 to be built with catkin (I tested `catkin_tools` on ROS 1).

The setup:
* OS: `Ubuntu 18.04`
* ROS version: `Melodic`
* Architecture: `x64`
* Build type: `catkin_tools`

Without the fix, it returns: 

```log
[build] Warning: Skipping package `behaviortree_cpp_v3` because it has an unsupported package build type: `ament_cmake`
```

I believe that conditionals are **not** supported in catkin, yet, having both `build_type` makes it work for catkin.

As: `build_x64/behaviortree_cpp_v3/catkin_generated/stamps/behaviortree_cpp_v3/package.xml.stamp`

```xml
<?xml version="1.0"?>
<package format="3">
  <name>behaviortree_cpp_v3</name>
  <version>3.3.0</version>
  <description>
  This package provides the Behavior Trees core library.
  </description>

  <maintainer email="davide.faconti@gmail.com">Davide Faconti</maintainer>

  <license>MIT</license>

  <author>Michele Colledanchise</author>
  <author>Davide Faconti</author>

  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
  <depend condition="$ROS_VERSION == 1">roslib</depend>

  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
  <depend condition="$ROS_VERSION == 2">rclcpp</depend>

  <depend>libzmq3-dev</depend>

  <export>
      <build_type condition="$ROS_VERSION == 1">catkin</build_type>
      <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
  </export>

</package>
```