### PR TITLE
Add extern "C" to correct the linkage for Windows

### DIFF
--- a/include/behaviortree_cpp_v3/bt_factory.h
+++ b/include/behaviortree_cpp_v3/bt_factory.h
@@ -113,7 +113,7 @@ See examples for more information about configuring CMake correctly
 #elif _WIN32
 
 #define BT_REGISTER_NODES(factory)                                                                 \
-		__declspec(dllexport) void BT_RegisterNodesFromPlugin(BT::BehaviorTreeFactory& factory)
+    extern "C" void __declspec(dllexport) BT_RegisterNodesFromPlugin(BT::BehaviorTreeFactory& factory)
 #endif
 
 #endif


### PR DESCRIPTION
This is found when I was exercising the [`virtual navigation`](http://emanual.robotis.com/docs/en/platform/turtlebot3/ros2_simulation/#virtual-navigation-with-turtlebot3) with TurtleBot3 and [`Navigation2`](https://ros-planning.github.io/navigation2/) for `ROS 2` on Windows, where I saw many BT plugins are failed to load.

And it turned out that that without `extern "C"`, the `C++` style name mangling is in use and one cannot simply get procedure address on Windows by the plain name `BT_RegisterNodesFromPlugin`.

This change is to be explicit about what's the name mangling should be used.