### PR TITLE
Use CMake 3.5.1 as the minimum CMake version for Xenial

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.2) # version on Ubuntu Xenial
+cmake_minimum_required(VERSION 3.5.1) # version on Ubuntu Xenial
 project(behaviortree_cpp_v3)
 
 #---- Add the subdirectory cmake ----

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.2)
+cmake_minimum_required(VERSION 3.5.1)
 
 include_directories( ../sample_nodes )
 

--- a/sample_nodes/CMakeLists.txt
+++ b/sample_nodes/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.2)
+cmake_minimum_required(VERSION 3.5.1)
 
 include_directories( ../include )
 
@@ -36,4 +36,4 @@ target_compile_definitions(movebase_node_dyn PRIVATE  BT_PLUGIN_EXPORT )
 set_target_properties(movebase_node_dyn PROPERTIES LIBRARY_OUTPUT_DIRECTORY
     ${BEHAVIOR_TREE_BIN_DESTINATION} )
 
- 
+


### PR DESCRIPTION
This allows configuring on Ubuntu 16.04.

CMake 3.5.1 is the latest version in Xenial, see:

- [xenial](https://packages.ubuntu.com/search?suite=xenial&searchon=names&keywords=cmake)
- [xenial-updates](https://packages.ubuntu.com/search?suite=xenial-updates&searchon=names&keywords=cmake)