### PR TITLE
catkin C++17 string_view compatibility

### DIFF
--- a/src/blackboard.cpp
+++ b/src/blackboard.cpp
@@ -44,7 +44,7 @@ const PortInfo* Blackboard::portInfo(const std::string &key)
 
 void Blackboard::addSubtreeRemapping(StringView internal, StringView external)
 {
-    internal_to_external_.insert( {internal.to_string(), external.to_string()} );
+    internal_to_external_.insert( {static_cast<std::string>(internal), static_cast<std::string>(external)} );
 }
 
 void Blackboard::debugMessage() const

--- a/src/bt_factory.cpp
+++ b/src/bt_factory.cpp
@@ -165,7 +165,7 @@ std::vector<std::string> getCatkinLibraryPaths()
             splitString(env_catkin_prefix_paths, os_pathsep);
         for (BT::StringView catkin_prefix_path : catkin_prefix_paths)
         {
-            filesystem::path path(catkin_prefix_path.to_string());
+            filesystem::path path(static_cast<std::string>(catkin_prefix_path));
             filesystem::path lib("lib");
             lib_paths.push_back((path / lib).str());
         }


### PR DESCRIPTION
- Use static_cast instead of to_string()

My system
- Ubuntu 18.04.4 LTS 4.15.0-96-generic
- catkin_tools 0.4.5
- `ROS_DISTRO` melodic
- clang version 10.0.0 (https://github.com/llvm/llvm-project.git ca9dfdfaecaa13fc075858a2965fd2f43e7bc8e1)
- using `CXX_STANDARD 17`
- BehaviorTree.CPP master d3667ce

I got the following error with `catkin build`
```make
ws/src/BehaviorTree.CPP/src/bt_factory.cpp:168:54: error: no member named 'to_string' in 'std::basic_string_view<char, std::char_traits<char> >'
            filesystem::path path(catkin_prefix_path.to_string());
                                  ~~~~~~~~~~~~~~~~~~ ^
1 error generated.
make[2]: *** [CMakeFiles/behaviortree_cpp_v3.dir/src/bt_factory.cpp.o] Error 1
```
I guess that you used `.to_string()` provided by [string-view-lite](https://github.com/martinmoene/string-view-lite) previously.

A quick fix builds successful
```diff
- filesystem::path path(catkin_prefix_path.to_string());
+ filesystem::path path(static_cast<std::string>(catkin_prefix_path));
```

Not checked for other CXX versions and/or compilers/ backwards compatibility. Would be nice if someone could check it.