### PR TITLE
[Windows] Compare `std::type_info` objects to check type.

### DIFF
--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -529,7 +529,7 @@ TreeNode::Ptr XMLParser::Pimpl::createNodeFromXML(const XMLElement *element,
                 else{
                     // found. check consistency
                     if( prev_info->type() && port_info.type()  && // null type means that everything is valid
-                        prev_info->type()!= port_info.type())
+                        *prev_info->type() != *port_info.type())
                     {
                         blackboard->debugMessage();
 


### PR DESCRIPTION
This problem is rendered at least on Windows side. I kept seeing the runtime error for two same data types. https://github.com/BehaviorTree/BehaviorTree.CPP/blob/master/src/xml_parsing.cpp#L536

The current logic is to check the pointers of two `std::type_info` objects. Perhaps on Linux it will be the same address, but on Windows side, it does require do the comparison by invoking the [compare operator](https://en.cppreference.com/w/cpp/types/type_info/operator_cmp).