### PR TITLE
Add XML parsing support for custom Control Nodes

### DIFF
--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -251,7 +251,7 @@ void VerifyXML(const std::string& xml_text,
         {
             const char* name = node->Name();
             if (StrEqual(name, "Action") || StrEqual(name, "Decorator") ||
-                    StrEqual(name, "SubTree") || StrEqual(name, "Condition"))
+                    StrEqual(name, "SubTree") || StrEqual(name, "Condition") || StrEqual(name, "Control"))
             {
                 const char* ID = node->Attribute("ID");
                 if (!ID)
@@ -307,6 +307,19 @@ void VerifyXML(const std::string& xml_text,
             {
                ThrowError(node->GetLineNum(),
                                    "The node <Condition> must have the attribute [ID]");
+            }
+        }
+        else if (StrEqual(name, "Control"))
+        {
+            if (children_count == 0)
+            {
+               ThrowError(node->GetLineNum(),
+                                   "The node <Control> must have at least 1 child");
+            }
+            if (!node->Attribute("ID"))
+            {
+               ThrowError(node->GetLineNum(),
+                                   "The node <Control> must have the attribute [ID]");
             }
         }
         else if (StrEqual(name, "Sequence") ||
@@ -443,7 +456,8 @@ TreeNode::Ptr XMLParser::Pimpl::createNodeFromXML(const XMLElement *element,
     std::string instance_name;
 
     // Actions and Decorators have their own ID
-    if (element_name == "Action" || element_name == "Decorator" || element_name == "Condition")
+    if (element_name == "Action" || element_name == "Decorator" ||
+        element_name == "Condition" || element_name == "Control")
     {
         ID = element->Attribute("ID");
     }


### PR DESCRIPTION
Signed-off-by: Sarathkrishnan Ramesh <sarathkrishnan99@gmail.com>

## Basic Info
|Info||
|---|---|
|Ticket address|Related to Groot [#84](https://github.com/BehaviorTree/Groot/issues/84)|
|Primay OS tested on|Ubuntu 18.04|
|Tested using| Navigation2 + TurtleBot3 simulation|

## Description
Added support for parsing custom control nodes when exported using Groot. For example: 
```xml
<root main_tree_to_execute="MainTree">
    <BehaviorTree ID="MainTree">
        <Control ID="PipelineSequence" name="NavigateWithReplanning">
            <Decorator ID="DistanceController" distance="1.0">
                <Action ID="ComputePathToPose" goal="{goal}" path="{path}" planner_id="GridBased"/>
            </Decorator>
            <Action ID="FollowPath" controller_id="FollowPath" path="{path}"/>
        </Control>
    </BehaviorTree>
    <TreeNodesModel>
        <!--- Other Nodes -->
        <Control ID="PipelineSequence"/>
    </TreeNodesModel>
</root>
```

## Future Work
I am not a 100% sure but Groot doesn't support monitoring when using custom Control Nodes.