### PR TITLE
Improved switching BTs with active Groot monitoring (ZMQ logger destruction)

### DIFF
--- a/src/loggers/bt_zmq_publisher.cpp
+++ b/src/loggers/bt_zmq_publisher.cpp
@@ -76,8 +76,9 @@ PublisherZMQ::PublisherZMQ(const BT::Tree& tree,
             catch (zmq::error_t& err)
             {
                 if (err.num() == ETERM)
+                {
                     std::cout << "[PublisherZMQ] Server quitting." << std::endl;
-
+                }
                 std::cout << "[PublisherZMQ] just died. Exeption " << err.what() << std::endl;
                 active_server_ = false;
             }
@@ -90,9 +91,7 @@ PublisherZMQ::PublisherZMQ(const BT::Tree& tree,
 PublisherZMQ::~PublisherZMQ()
 {
     active_server_ = false;
-
     zmq_->context.shutdown();
-
     if (thread_.joinable())
     {
         thread_.join();
@@ -174,8 +173,9 @@ void PublisherZMQ::flush()
     catch (zmq::error_t& err)
     {
         if (err.num() == ETERM)
+        {
             std::cout << "[PublisherZMQ] Publisher quitting." << std::endl;
-
+        }
         std::cout << "[PublisherZMQ] just died. Exeption " << err.what() << std::endl;
     }
     


### PR DESCRIPTION
Switching BTs with active ZMQ logging (for Groot) enabled increased the switching time varying from ~20-99ms.

Switching is performed by destructing the zmq logger, loading a new tree based on xml with currently the same factory (plugins), and finally adding a new zmq logger to the new tree. For reference, see this PR here: https://github.com/ros-planning/navigation2/pull/1958

This is due to the timeout set for the ZMQ server. The detached thread always waits the timeout before the next while loop starts (which would end if the server is requested to end through the global variable).

https://github.com/BehaviorTree/BehaviorTree.CPP/blob/f54f6d83e5c06f44eae2b4d9700f5178dbdb4159/src/loggers/bt_zmq_publisher.cpp#L68
( Timeout set in line 57 + 58 )

After consulting the ZMQ documentation, a few functions promised to directly halt any ongoing requests in the ZMQ context.

See the documentation here: 
http://api.zeromq.org/master:zmq-ctx-shutdown

> Context shutdown will cause any blocking operations currently in progress on sockets open within context to return immediately with an error code of ETERM. [...]

**This successfully decreased the max blocking time of 100ms to 1 - 1,5ms for deconstructing the zmq logger.**

( close() is already performed afterwards by the default constructor of the server and publisher objects -> `delete zmq_` )