### PR TITLE
ReactiveSequence doesn't behave as it should

### DIFF
--- a/src/controls/reactive_sequence.cpp
+++ b/src/controls/reactive_sequence.cpp
@@ -40,6 +40,7 @@ NodeStatus ReactiveSequence::tick()
 
             case NodeStatus::FAILURE:
             {
+                haltChildren();
                 index = 0;
                 running_count = 0;
                 return NodeStatus::RUNNING;

--- a/src/controls/reactive_sequence.cpp
+++ b/src/controls/reactive_sequence.cpp
@@ -40,8 +40,9 @@ NodeStatus ReactiveSequence::tick()
 
             case NodeStatus::FAILURE:
             {
-                haltChildren();
-                return NodeStatus::FAILURE;
+                index = 0;
+                running_count = 0;
+                return NodeStatus::RUNNING;
             }
             case NodeStatus::SUCCESS:
             {


### PR DESCRIPTION
Currently, the `ReactiveSequence` node doesn't seem to "RESTART" as mentioned here: https://www.behaviortree.dev/sequencenode/
Maybe there is a better way to do this (I'd be happy to update my PR based on feedback), but these changes seem to work.

@facontidavide 