### PR TITLE
Fix bug on halt of delay node

### DIFF
--- a/include/behaviortree_cpp_v3/decorators/delay_node.h
+++ b/include/behaviortree_cpp_v3/decorators/delay_node.h
@@ -39,6 +39,7 @@ class DelayNode : public DecoratorNode
     }
     void halt() override
     {
+        delay_started_ = false;
         timer_.cancelAll();
         DecoratorNode::halt();
     }

--- a/src/decorators/delay_node.cpp
+++ b/src/decorators/delay_node.cpp
@@ -37,6 +37,7 @@ NodeStatus DelayNode::tick()
     if (!delay_started_)
     {
         delay_complete_ = false;
+        delay_aborted_ = false;
         delay_started_ = true;
         setStatus(NodeStatus::RUNNING);
 


### PR DESCRIPTION
 - When DelayNode is halted and ticked again, it always returned FAILURE since the state of DelayNode was not properly reset.
 - This commit fixes unexpected behavior of DelayNode when it is halted.