### PR TITLE
Registered missing dummy nodes for examples

### DIFF
--- a/sample_nodes/dummy_nodes.cpp
+++ b/sample_nodes/dummy_nodes.cpp
@@ -22,6 +22,12 @@ BT::NodeStatus CheckTemperature()
     return BT::NodeStatus::SUCCESS;
 }
 
+BT::NodeStatus SayHello()
+{
+    std::cout << "Robot says: Hello World" << std::endl;
+    return BT::NodeStatus::SUCCESS;
+}
+
 BT::NodeStatus GripperInterface::open()
 {
     _opened = true;

--- a/sample_nodes/dummy_nodes.cpp
+++ b/sample_nodes/dummy_nodes.cpp
@@ -16,6 +16,12 @@ BT::NodeStatus CheckBattery()
     return BT::NodeStatus::SUCCESS;
 }
 
+BT::NodeStatus CheckTemperature()
+{
+    std::cout << "[ Temperature: OK ]" << std::endl;
+    return BT::NodeStatus::SUCCESS;
+}
+
 BT::NodeStatus GripperInterface::open()
 {
     _opened = true;

--- a/sample_nodes/dummy_nodes.h
+++ b/sample_nodes/dummy_nodes.h
@@ -10,6 +10,7 @@ namespace DummyNodes
 BT::NodeStatus CheckBattery();
 
 BT::NodeStatus CheckTemperature();
+BT::NodeStatus SayHello();
 
 class GripperInterface
 {
@@ -72,6 +73,7 @@ inline void RegisterNodes(BT::BehaviorTreeFactory& factory)
 
     factory.registerSimpleCondition("CheckBattery", std::bind(CheckBattery));
     factory.registerSimpleCondition("CheckTemperature", std::bind(CheckTemperature));
+    factory.registerSimpleAction("SayHello", std::bind(SayHello));
     factory.registerSimpleAction("OpenGripper", std::bind(&GripperInterface::open, &grip_singleton));
     factory.registerSimpleAction("CloseGripper", std::bind(&GripperInterface::close, &grip_singleton));
     factory.registerNodeType<ApproachObject>("ApproachObject");

--- a/sample_nodes/dummy_nodes.h
+++ b/sample_nodes/dummy_nodes.h
@@ -9,6 +9,8 @@ namespace DummyNodes
 
 BT::NodeStatus CheckBattery();
 
+BT::NodeStatus CheckTemperature();
+
 class GripperInterface
 {
   public:
@@ -69,6 +71,7 @@ inline void RegisterNodes(BT::BehaviorTreeFactory& factory)
     static GripperInterface grip_singleton;
 
     factory.registerSimpleCondition("CheckBattery", std::bind(CheckBattery));
+    factory.registerSimpleCondition("CheckTemperature", std::bind(CheckTemperature));
     factory.registerSimpleAction("OpenGripper", std::bind(&GripperInterface::open, &grip_singleton));
     factory.registerSimpleAction("CloseGripper", std::bind(&GripperInterface::close, &grip_singleton));
     factory.registerNodeType<ApproachObject>("ApproachObject");


### PR DESCRIPTION
Example t10_include_trees was failing because nodes `CheckTemperature` and `SayHello` were not registered with the factory.

Fixes #259