### PR TITLE
Update fallback documentation to V3

### DIFF
--- a/docs/BT_basics.md
+++ b/docs/BT_basics.md
@@ -39,7 +39,7 @@ The first two, as their names suggests, inform their parent that their operation
  was a success or a failure.
 
 RUNNING is returned by __asynchronous__ nodes when their execution is not 
-completed and they needs more time to return a valid result.
+completed and they need more time to return a valid result.
 
 __Asynchronous nodes can be halted__.
 

--- a/docs/FallbackNode.md
+++ b/docs/FallbackNode.md
@@ -5,6 +5,11 @@ in other frameworks.
 
 Their purpose is to try different strategies, until we find one that "works".
 
+Currently the framework provides two kinds of nodes:
+
+- Fallback
+- ReactiveFallback
+
 They share the following rules:
 
 - Before ticking the first child, the node status becomes __RUNNING__.
@@ -17,14 +22,19 @@ They share the following rules:
 - If a child returns __SUCCESS__, it stops and returns __SUCCESS__.
   All the children are halted. 
 
-The two versions of Fallback differ in the way they react when a child returns
-RUNNING:
+To understand how the two ControlNodes differ, refer to the following table:
 
-- FallbackStar will return RUNNING and the next time it is ticked,
- it will tick the same child where it left off before.
- 
-- Plain old Fallback will return RUNNING and the index of the next child to
- execute is reset after each execution.
+| Type of ControlNode | Child returns RUNNING |
+|---|:---:|
+| Fallback | Tick again  |
+| ReactiveFallback  |  Restart |
+
+- "__Restart__" means that the entire fallback is restarted from the first 
+  child of the list.
+
+- "__Tick again__" means that the next time the fallback is ticked, the 
+  same child is ticked again. Previous sibling, which returned FAILURE already,
+  are not ticked again.
 
 ## Fallback
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ __BehaviorTree.CPP__ has many interesting features, when compared to other imple
 
 - It makes asynchronous Actions, i.e. non-blocking, a first-class citizen.
 - It allows the creation of trees at run-time, using a textual representation (XML).
-- You can link staticaly you custom TreeNodes or convert them into plugins 
+- You can link staticaly your custom TreeNodes or convert them into plugins
 which are loaded at run-time.
 - It includes a __logging/profiling__ infrastructure that allows the user 
 to visualize, record, replay and analyze state transitions.


### PR DESCRIPTION
Hello and as always thanks for the great work!

Updating the FallbackNode description to V3 (no more FallbackStar!) while trying to resemble at most the explanation given in [SequenceNode.md](https://github.com/BehaviorTree/BehaviorTree.CPP/blob/master/docs/SequenceNode.md).

Also fixing a couple of unrelated typos in my way there.