### PR TITLE
Use pedantic for non MSVC builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(MSVC)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+else()
+    add_definitions(-Wpedantic)
 endif()
-
-add_definitions(-Wpedantic)
 
 #---- Include boost to add coroutines ----
 find_package(Boost COMPONENTS coroutine QUIET)


### PR DESCRIPTION
MSVC builds are currently failing due to:

`invalid numeric argument '/Wpedantic'`	

Only use pedantic for non MSVC builds.