### PR TITLE
Fix CatchSignal for Windows

### DIFF
--- a/tools/bt_recorder.cpp
+++ b/tools/bt_recorder.cpp
@@ -16,12 +16,17 @@ static void s_signal_handler(int)
 
 static void CatchSignals(void)
 {
+#ifdef _WIN32
+    signal(SIGINT, s_signal_handler);
+    signal(SIGTERM, s_signal_handler);
+#else
     struct sigaction action;
     action.sa_handler = s_signal_handler;
     action.sa_flags = 0;
     sigemptyset(&action.sa_mask);
     sigaction(SIGINT, &action, nullptr);
     sigaction(SIGTERM, &action, nullptr);
+#endif
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
Since `sigemptyset` and `sigaction` are POSIX only, they aren't supported on Windows. I used the Windows equivalent to fix the build on Windows.