### PR TITLE
Add ENABLE_COROUTINES CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,12 +32,6 @@ if(Boost_FOUND)
     include_directories(${Boost_INCLUDE_DIRS})
 endif()
 
-
-if(NOT DEFINED BT_COROUTINES)
-    message(STATUS "Coroutines disabled. Install Boost to enable them (version 1.59+ recommended).")
-    add_definitions(-DBT_NO_COROUTINES)
-endif()
-
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 #---- project configuration ----
@@ -45,6 +39,12 @@ option(BUILD_EXAMPLES   "Build tutorials and examples" ON)
 option(BUILD_UNIT_TESTS "Build the unit tests" ON)
 option(BUILD_TOOLS "Build commandline tools" ON)
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+option(DISABLE_COROUTINES "Disable coroutines" OFF)
+
+if(DISABLE_COROUTINES OR NOT DEFINED BT_COROUTINES)
+    message(STATUS "Coroutines disabled. Install Boost (version 1.59+ recommended) and ensure DISABLE_COROUTINES is not set to enable them.")
+    add_definitions(-DBT_NO_COROUTINES)
+endif()
 
 #---- Find other packages ----
 find_package(Threads)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,23 +15,6 @@ else()
     add_definitions(-Wpedantic)
 endif()
 
-#---- Include boost to add coroutines ----
-find_package(Boost COMPONENTS coroutine QUIET)
-
-if(Boost_FOUND)
-    string(REPLACE "." "0" Boost_VERSION_NODOT ${Boost_VERSION})
-    if(NOT Boost_VERSION_NODOT VERSION_LESS 105900)
-        message(STATUS "Found boost::coroutine2.")
-        add_definitions(-DBT_BOOST_COROUTINE2)
-        set(BT_COROUTINES true)
-    elseif(NOT Boost_VERSION_NODOT VERSION_LESS 105300)
-        message(STATUS "Found boost::coroutine.")
-        add_definitions(-DBT_BOOST_COROUTINE)
-        set(BT_COROUTINES true)
-    endif()
-    include_directories(${Boost_INCLUDE_DIRS})
-endif()
-
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 #---- project configuration ----
@@ -39,10 +22,31 @@ option(BUILD_EXAMPLES   "Build tutorials and examples" ON)
 option(BUILD_UNIT_TESTS "Build the unit tests" ON)
 option(BUILD_TOOLS "Build commandline tools" ON)
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
-option(DISABLE_COROUTINES "Disable coroutines" OFF)
+option(ENABLE_COROUTINES "Enable boost coroutines" ON)
 
-if(DISABLE_COROUTINES OR NOT DEFINED BT_COROUTINES)
-    message(STATUS "Coroutines disabled. Install Boost (version 1.59+ recommended) and ensure DISABLE_COROUTINES is not set to enable them.")
+#---- Include boost to add coroutines ----
+if(ENABLE_COROUTINES)
+    find_package(Boost COMPONENTS coroutine QUIET)
+
+    if(Boost_FOUND)
+        string(REPLACE "." "0" Boost_VERSION_NODOT ${Boost_VERSION})
+        if(NOT Boost_VERSION_NODOT VERSION_LESS 105900)
+            message(STATUS "Found boost::coroutine2.")
+            add_definitions(-DBT_BOOST_COROUTINE2)
+            set(BT_COROUTINES true)
+        elseif(NOT Boost_VERSION_NODOT VERSION_LESS 105300)
+            message(STATUS "Found boost::coroutine.")
+            add_definitions(-DBT_BOOST_COROUTINE)
+            set(BT_COROUTINES true)
+        endif()
+        include_directories(${Boost_INCLUDE_DIRS})
+    endif()
+
+    if(NOT DEFINED BT_COROUTINES)
+        message(STATUS "Boost coroutines disabled. Install Boost (version 1.59+ recommended).")
+    endif()
+else()
+    message(STATUS "Boost coroutines disabled by CMake option.")
     add_definitions(-DBT_NO_COROUTINES)
 endif()
 


### PR DESCRIPTION
Some organizations, particularly ones with strict threading models, may want to disable coroutines from the build, even if a sufficient Boost version is present on their system. This PR just exposes a new DISABLE_COROUTINES CMake option so that the user may forcefully disable them. 