### PR TITLE
[Fix] Fix CMake version warning and -Wformat warning

### DIFF
--- a/src/controls/manual_node.cpp
+++ b/src/controls/manual_node.cpp
@@ -155,7 +155,7 @@ uint8_t ManualSelectorNode::selectChild() const
     // now print all the menu items and highlight the first one
     for(size_t i=0; i<list.size(); i++ )
     {
-        mvwprintw( win, i+5, 0, "%2d. %s", i+1, list[i].c_str() );
+        mvwprintw( win, i+5, 0, "%2ld. %s", i+1, list[i].c_str() );
     }
 
     wrefresh( win ); // update the terminal screen

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 
 add_executable(bt3_log_cat         bt_log_cat.cpp )


### PR DESCRIPTION
Fix 

CMake warning 

```
CMake Deprecation Warning at tools/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

and

-Wformat warning

```
 warning: format ‘%d’ expects argument of type ‘int’, but argument 5 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
  158 |         mvwprintw( win, i+5, 0, "%2d. %s", i+1, list[i].c_str() );
      |                                  ~~^       ~~~
      |                                    |        |
      |                                    int      size_t {aka long unsigned int}
      |                                  %2ld

```

Signed-off-by: Homalozoa <xuhaiwang@xiaomi.com>