### PR TITLE
Specify ROS version function uses

### DIFF
--- a/include/behaviortree_cpp_v3/bt_factory.h
+++ b/include/behaviortree_cpp_v3/bt_factory.h
@@ -264,8 +264,8 @@ public:
     void registerFromPlugin(const std::string &file_path);
 
     /**
-     * @brief registerFromROSPlugins finds all shared libraries that export ROS plugins for behaviortree_cpp, and calls registerFromPlugin for each library.
-     * @throws If not compiled with ROS support or if the library cannot load for any reason
+     * @brief registerFromROSPlugins finds all shared libraries that export ROS1 plugins for behaviortree_cpp, and calls registerFromPlugin for each library.
+     * @throws If not compiled with ROS1 support or if the library cannot load for any reason
      *
      */
     void registerFromROSPlugins();


### PR DESCRIPTION
I was trying to get the same behavior in ROS2. But this function at least didn't do the job.