### PR TITLE
Don't restart SequenceStar on halt

### DIFF
--- a/src/controls/sequence_star_node.cpp
+++ b/src/controls/sequence_star_node.cpp
@@ -74,7 +74,7 @@ NodeStatus SequenceStarNode::tick()
 
 void SequenceStarNode::halt()
 {
-    current_child_idx_ = 0;
+    // DO NOT reset current_child_idx_ on halt
     ControlNode::halt();
 }
 

--- a/tests/gtest_sequence.cpp
+++ b/tests/gtest_sequence.cpp
@@ -458,3 +458,89 @@ TEST_F(ComplexSequenceWithMemoryTest, Action1DoneSeq)
     ASSERT_EQ(NodeStatus::IDLE, action_1.status());
     ASSERT_EQ(NodeStatus::IDLE, action_2.status());
 }
+
+TEST_F(ComplexSequenceWithMemoryTest, Action2FailureSeq)
+{
+    root.executeTick();
+    std::this_thread::sleep_for(milliseconds(150));
+    root.executeTick();
+
+    ASSERT_EQ(NodeStatus::SUCCESS, seq_conditions.status());
+    ASSERT_EQ(NodeStatus::IDLE, condition_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, condition_2.status());
+    ASSERT_EQ(NodeStatus::RUNNING, seq_actions.status());
+    ASSERT_EQ(NodeStatus::SUCCESS, action_1.status());
+    ASSERT_EQ(NodeStatus::RUNNING, action_2.status());
+
+    action_2.setExpectedResult(NodeStatus::FAILURE);
+    std::this_thread::sleep_for(milliseconds(150));
+    root.executeTick();
+
+    // failure in action_2 does not affect the state of already
+    // executed nodes (seq_conditions and action_1)
+    ASSERT_EQ(NodeStatus::FAILURE, root.status());
+    ASSERT_EQ(NodeStatus::SUCCESS, seq_conditions.status());
+    ASSERT_EQ(NodeStatus::IDLE, condition_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, condition_2.status());
+    ASSERT_EQ(NodeStatus::IDLE, seq_actions.status());
+    ASSERT_EQ(NodeStatus::SUCCESS, action_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, action_2.status());
+
+    action_2.setExpectedResult(NodeStatus::SUCCESS);
+    root.executeTick();
+
+    ASSERT_EQ(NodeStatus::SUCCESS, seq_conditions.status());
+    ASSERT_EQ(NodeStatus::IDLE, condition_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, condition_2.status());
+    ASSERT_EQ(NodeStatus::RUNNING, seq_actions.status());
+    ASSERT_EQ(NodeStatus::SUCCESS, action_1.status());
+    ASSERT_EQ(NodeStatus::RUNNING, action_2.status());
+
+    std::this_thread::sleep_for(milliseconds(150));
+    root.executeTick();
+
+    ASSERT_EQ(NodeStatus::SUCCESS, root.status());
+    ASSERT_EQ(NodeStatus::IDLE, seq_conditions.status());
+    ASSERT_EQ(NodeStatus::IDLE, condition_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, condition_2.status());
+    ASSERT_EQ(NodeStatus::IDLE, seq_actions.status());
+    ASSERT_EQ(NodeStatus::IDLE, action_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, action_2.status());
+}
+
+TEST_F(ComplexSequenceWithMemoryTest, Action2HaltSeq)
+{
+    root.executeTick();
+    std::this_thread::sleep_for(milliseconds(150));
+    root.executeTick();
+
+    root.halt();
+
+    ASSERT_EQ(NodeStatus::IDLE, seq_conditions.status());
+    ASSERT_EQ(NodeStatus::IDLE, condition_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, condition_2.status());
+    ASSERT_EQ(NodeStatus::IDLE, seq_actions.status());
+    ASSERT_EQ(NodeStatus::IDLE, action_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, action_2.status());
+
+    root.executeTick();
+
+    // tree retakes execution from action_2
+    ASSERT_EQ(NodeStatus::IDLE, seq_conditions.status());
+    ASSERT_EQ(NodeStatus::IDLE, condition_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, condition_2.status());
+    ASSERT_EQ(NodeStatus::RUNNING, seq_actions.status());
+    ASSERT_EQ(NodeStatus::IDLE, action_1.status());
+    ASSERT_EQ(NodeStatus::RUNNING, action_2.status());
+
+    std::this_thread::sleep_for(milliseconds(150));
+    root.executeTick();
+
+    ASSERT_EQ(NodeStatus::SUCCESS, root.status());
+    ASSERT_EQ(NodeStatus::IDLE, seq_conditions.status());
+    ASSERT_EQ(NodeStatus::IDLE, condition_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, condition_2.status());
+    ASSERT_EQ(NodeStatus::IDLE, seq_actions.status());
+    ASSERT_EQ(NodeStatus::IDLE, action_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, action_2.status());
+}

--- a/tests/gtest_sequence.cpp
+++ b/tests/gtest_sequence.cpp
@@ -387,7 +387,7 @@ TEST_F(ComplexSequenceWithMemoryTest, ConditionsTrue)
     ASSERT_EQ(NodeStatus::IDLE, action_2.status());
 }
 
-TEST_F(ComplexSequenceWithMemoryTest, Conditions1ToFase)
+TEST_F(ComplexSequenceWithMemoryTest, Conditions1ToFalse)
 {
     BT::NodeStatus state = root.executeTick();
 


### PR DESCRIPTION
This might need some discussion, but I am pretty sure it's a bug.

The problem:
SequenceStar resets progress when halted https://github.com/BehaviorTree/BehaviorTree.CPP/blob/master/src/controls/sequence_star_node.cpp#L77

So in reactive formulations such as the example image below (also used in the documentation), if the battery check fails during GoTo=B, GoTo=A will be re-executed in the next sequence tick. Since we are using SequenceStar to avoid repeating actions which have already returned SUCESS, the execution should be resumed from GoTo=B even after halted.
![SequenceStar](https://user-images.githubusercontent.com/20625381/150068128-5b3a85a7-576a-4be9-a8e1-9d8e760489aa.png)

