### PR TITLE
Build Sample Nodes By Default to Fix Github Action

### DIFF
--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -13,7 +13,7 @@ jobs:
     - name: apt
       run: sudo apt-get update && sudo apt-get install -yq libzmq3-dev libdw-dev libgtest-dev cmake
     - name: Install gtest manually
-      run: cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp *.a /usr/lib 
+      run: cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib 
     # build project
     - name: mkdir
       run: mkdir build
@@ -23,5 +23,5 @@ jobs:
       run: cmake --build build/ --target all
     # run tests
     - name: run test
-      run: build/test/behaviortree_cpp_v3_test
+      run: build/bin/behaviortree_cpp_v3_test
 

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -13,7 +13,8 @@ jobs:
     - name: apt
       run: sudo apt-get update && sudo apt-get install -yq libzmq3-dev libdw-dev libgtest-dev cmake
     - name: Install gtest manually
-      run: cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib 
+      working-directory: /usr/src/gtest
+      run: sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib
     # build project
     - name: mkdir
       run: mkdir build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 #---- project configuration ----
 option(BUILD_EXAMPLES   "Build tutorials and examples" ON)
+option(BUILD_SAMPLES    "Build sample nodes" ON)
 option(BUILD_UNIT_TESTS "Build the unit tests" ON)
 option(BUILD_TOOLS "Build commandline tools" ON)
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)


### PR DESCRIPTION
The CMake option `BUILD_SAMPLES` was added in #315 but not enabled by default.  This causes all tests to be disabled by default, causing the github action "build and run tests" to fail