### PR TITLE
Dima/fix async action node

### DIFF
--- a/include/behaviortree_cpp_v3/action_node.h
+++ b/include/behaviortree_cpp_v3/action_node.h
@@ -17,6 +17,8 @@
 #include <atomic>
 #include <thread>
 #include <future>
+#include <mutex>
+
 #include "leaf_node.h"
 
 namespace BT
@@ -135,6 +137,7 @@ class AsyncActionNode : public ActionNodeBase
     std::exception_ptr exptr_;
     std::atomic_bool halt_requested_;
     std::future<NodeStatus> thread_handle_;
+    std::mutex m_;
 };
 
 /**

--- a/package.xml
+++ b/package.xml
@@ -23,7 +23,8 @@
   <depend>libzmq3-dev</depend>
   <depend>libncurses-dev</depend>
   
-  <test_depend condition="$ROS_VERSION == 2">ament_cmake_gtest</test_depend>
+  <test_depend condition="$ROS_VERSION == 2">ament_cmake_gmock</test_depend>
+  <test_depend>libgmock-dev</test_depend>
 
   <export>
       <build_type condition="$ROS_VERSION == 1">catkin</build_type>

--- a/src/action_node.cpp
+++ b/src/action_node.cpp
@@ -167,6 +167,7 @@ void StatefulActionNode::halt()
 
 NodeStatus BT::AsyncActionNode::executeTick()
 {
+    using lock_type = std::unique_lock<std::mutex>;
     //send signal to other thread.
     // The other thread is in charge for changing the status
     if (status() == NodeStatus::IDLE)
@@ -182,16 +183,23 @@ NodeStatus BT::AsyncActionNode::executeTick()
             {
                 std::cerr << "\nUncaught exception from the method tick(): ["
                           << registrationName() << "/" << name() << "]\n" << std::endl;
+                // Set the exception pointer and the status atomically.
+                lock_type l(m_);
                 exptr_ = std::current_exception();
-                thread_handle_.wait();
+                setStatus(BT::NodeStatus::FAILURE);
             }
             return status();
         });
     }
 
+    lock_type l(m_);
     if( exptr_ )
     {
-        std::rethrow_exception(exptr_);
+        // The official interface of std::exception_ptr does not define any move
+        // semantics. Thus, we copy and reset exptr_ manually.
+        const auto exptr_copy = exptr_;
+        exptr_ = nullptr;
+        std::rethrow_exception(exptr_copy);
     }
     return status();
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,11 +24,17 @@ if (BT_COROUTINES)
     list(APPEND BT_TESTS  gtest_coroutines.cpp)
 endif()
 
+if(ament_cmake_FOUND OR catkin_FOUND)
+    # This test requires gmock. Since we don't have a uniform way to include
+    # gmock for non-users, it is turned of when build without ros.
+    list(APPEND BT_TESTS gtest_async_action_node.cpp)
+endif()
+
 if(ament_cmake_FOUND AND BUILD_TESTING)
 
-    find_package(ament_cmake_gtest REQUIRED)
+    find_package(ament_cmake_gmock REQUIRED)
 
-    ament_add_gtest_executable(${BEHAVIOR_TREE_LIBRARY}_test ${BT_TESTS})
+    ament_add_gmock_executable(${BEHAVIOR_TREE_LIBRARY}_test ${BT_TESTS})
     target_link_libraries(${BEHAVIOR_TREE_LIBRARY}_test ${BEHAVIOR_TREE_LIBRARY}
                                                         bt_sample_nodes
                                                         ${ament_LIBRARIES})
@@ -37,7 +43,7 @@ if(ament_cmake_FOUND AND BUILD_TESTING)
 
 elseif(catkin_FOUND AND CATKIN_ENABLE_TESTING)
 
-    catkin_add_gtest(${BEHAVIOR_TREE_LIBRARY}_test ${BT_TESTS})
+    catkin_add_gmock(${BEHAVIOR_TREE_LIBRARY}_test ${BT_TESTS})
     target_link_libraries(${BEHAVIOR_TREE_LIBRARY}_test ${BEHAVIOR_TREE_LIBRARY}
                                                         bt_sample_nodes
                                                         ${catkin_LIBRARIES})

--- a/tests/gtest_async_action_node.cpp
+++ b/tests/gtest_async_action_node.cpp
@@ -1,0 +1,137 @@
+#include "behaviortree_cpp_v3/action_node.h"
+#include "behaviortree_cpp_v3/basic_types.h"
+
+#include <string>
+#include <array>
+#include <chrono>
+#include <thread>
+#include <condition_variable>
+#include <mutex>
+#include <future>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+// The mocked version of the base.
+struct MockedAsyncActionNode : public BT::AsyncActionNode
+{
+    using BT::AsyncActionNode::AsyncActionNode;
+    MOCK_METHOD0(tick, BT::NodeStatus());
+
+    // Tick while the node is running.
+    void spinUntilDone()
+    {
+        do
+        {
+            executeTick();
+        } while (status() == BT::NodeStatus::RUNNING);
+    }
+};
+
+// The fixture taking care of the node-setup.
+struct MockedAsyncActionFixture : public testing::Test
+{
+    BT::NodeConfiguration config;
+    MockedAsyncActionNode sn;
+    MockedAsyncActionFixture() : sn("node", config)
+    {
+    }
+};
+
+// Parameters for the terminal node statii.
+struct NodeStatusFixture : public testing::WithParamInterface<BT::NodeStatus>,
+                           public MockedAsyncActionFixture
+{
+};
+
+INSTANTIATE_TEST_CASE_P(/**/, NodeStatusFixture,
+                        testing::Values(BT::NodeStatus::SUCCESS, BT::NodeStatus::FAILURE));
+
+TEST_P(NodeStatusFixture, normal_routine)
+{
+    // Test verifies the "normal" operation: We correctly propagate the result
+    // from the tick to the caller.
+    const BT::NodeStatus state = GetParam();
+
+    // Setup the mock-expectations.
+    EXPECT_CALL(sn, tick()).WillOnce(testing::Invoke([&]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        return state;
+    }));
+
+    // Initial status.
+    ASSERT_EQ(sn.status(), BT::NodeStatus::IDLE);
+
+    // Spin the node.
+    sn.spinUntilDone();
+
+    // Check the final status.
+    ASSERT_EQ(sn.status(), state);
+}
+
+TEST_F(MockedAsyncActionFixture, no_halt)
+{
+    // Test verifies that halt returns immediately, if the node is idle.
+    ASSERT_EQ(sn.status(), BT::NodeStatus::IDLE);
+    sn.halt();
+    ASSERT_TRUE(sn.isHaltRequested());
+
+    // Below we further verify that the halt flag is cleaned up properly.
+    EXPECT_CALL(sn, tick()).WillOnce(testing::Return(BT::NodeStatus::SUCCESS));
+
+    // Spin the node.
+    sn.spinUntilDone();
+
+    ASSERT_FALSE(sn.isHaltRequested());
+}
+
+TEST_F(MockedAsyncActionFixture, halt)
+{
+    // Test verifies calling halt is blocking.
+    bool release = false;
+    std::mutex m;
+    std::condition_variable cv;
+
+    const BT::NodeStatus state = BT::NodeStatus::SUCCESS;
+    EXPECT_CALL(sn, tick()).WillOnce(testing::Invoke([&]() {
+        // Sleep until we call "halt"
+        std::unique_lock<std::mutex> l(m);
+        while (!release)
+            cv.wait(l);
+
+        return state;
+    }));
+
+    // Start the execution.
+    sn.executeTick();
+
+    // Try to halt the node (cv will block it...)
+    std::future<void> halted = std::async(std::launch::async, [&]() { sn.halt(); });
+    ASSERT_EQ(halted.wait_for(std::chrono::milliseconds(10)), std::future_status::timeout);
+    ASSERT_EQ(sn.status(), BT::NodeStatus::RUNNING);
+
+    // Release the method.
+    {
+        std::unique_lock<std::mutex> l(m);
+        release = true;
+        cv.notify_one();
+    }
+
+    // Wait for the future to return.
+    halted.wait();
+    ASSERT_EQ(sn.status(), state);
+}
+
+TEST_F(MockedAsyncActionFixture, exception)
+{
+    // Verifies that we can recover from the exceptions in the tick method: 
+    // 1) catch the exception, 2) re-raise it in the caller thread, 3) recover.
+
+    // Setup the mock.
+    EXPECT_CALL(sn, tick()).WillRepeatedly(testing::Invoke([&]() {
+        throw std::runtime_error("This is not good!");
+        return BT::NodeStatus::SUCCESS;
+    }));
+
+    ASSERT_ANY_THROW(sn.spinUntilDone());
+}

--- a/tests/gtest_async_action_node.cpp
+++ b/tests/gtest_async_action_node.cpp
@@ -5,6 +5,7 @@
 #include <condition_variable>
 #include <future>
 #include <mutex>
+#include <stdexcept>
 #include <string>
 #include <thread>
 
@@ -27,7 +28,7 @@ struct MockedAsyncActionNode : public BT::AsyncActionNode
         return status();
     }
 
-    // Expose the setStatus call.
+    // Expose the setStatus method.
     using BT::AsyncActionNode::setStatus;
 };
 
@@ -131,10 +132,10 @@ TEST_F(MockedAsyncActionFixture, exception)
     }));
 
     ASSERT_ANY_THROW(sn.spinUntilDone());
+    testing::Mock::VerifyAndClearExpectations(&sn);
 
     // Now verify that the exception is cleared up (we succeed).
     sn.setStatus(BT::NodeStatus::IDLE);
-    testing::Mock::VerifyAndClearExpectations(&sn);
     const BT::NodeStatus state{BT::NodeStatus::SUCCESS};
     EXPECT_CALL(sn, tick()).WillOnce(testing::Return(state));
     ASSERT_EQ(sn.spinUntilDone(), state);

--- a/tests/gtest_async_action_node.cpp
+++ b/tests/gtest_async_action_node.cpp
@@ -94,7 +94,7 @@ TEST_F(MockedAsyncActionFixture, halt)
 
     const BT::NodeStatus state = BT::NodeStatus::SUCCESS;
     EXPECT_CALL(sn, tick()).WillOnce(testing::Invoke([&]() {
-        // Sleep until we call "halt"
+        // Sleep until we send the release signal.
         std::unique_lock<std::mutex> l(m);
         while (!release)
             cv.wait(l);

--- a/tests/gtest_async_action_node.cpp
+++ b/tests/gtest_async_action_node.cpp
@@ -1,13 +1,12 @@
 #include "behaviortree_cpp_v3/action_node.h"
 #include "behaviortree_cpp_v3/basic_types.h"
 
-#include <string>
-#include <array>
 #include <chrono>
-#include <thread>
 #include <condition_variable>
-#include <mutex>
 #include <future>
+#include <mutex>
+#include <string>
+#include <thread>
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>


### PR DESCRIPTION
Hey,

I've noticed that the AsyncActionNode has some strange bugs in the case the tick() method throws an exception. 

1. One problem was in the thread_handle_.wait() call from within the thread. With some unlucky scheduling it might happen, that the thread_handle_ is accessed from the "tick" thread before being initialized in the "main" thread. This would lead to a (uncought) future_error exception. As a side-note bonus: This type of bugs is so prevalent, that they've made it into [this](https://www.cs.columbia.edu/~junfeng/09fa-e6998/papers/concurrency-bugs.pdf) paper (under Figure 2 from Mozilla :smile_cat:  ). Another problem is that (at least AFAIS - maybe I've missed something) there is no way to pass the wait barrier in the "tick" thread once an exception occurs.
2. Another problem is that the exptr is not cleaned up once populated - The class would keep throwing the same exception on every subsequent tick.

I've tried to add some unit tests to verify that the changes are correct. For the testing I've relied on gmock. Here I'm not entirely sure how to handle the dependencies for gmock - especially for ROS2 and non-ROS users. Maybe someone can comment on that.

Please note also that I've made a (hopefully sensible) assumption that the "tick" thread should return Failure if an exception occurs.
