### PR TITLE
Export dependency on ament_index_cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,7 @@ endif()
 if(ament_cmake_FOUND)
     find_package(ament_index_cpp REQUIRED)
     ament_target_dependencies(${BEHAVIOR_TREE_LIBRARY} PUBLIC ament_index_cpp)
+    ament_export_dependencies(ament_index_cpp)
 
     set( BEHAVIOR_TREE_LIB_DESTINATION   lib )
     set( BEHAVIOR_TREE_INC_DESTINATION   include )


### PR DESCRIPTION
To make dependent packages try to link ament_index_cpp, export the
dependency explicitly.