### PR TITLE
threshold child count dynamically in parallel control node

### DIFF
--- a/include/behaviortree_cpp_v3/controls/parallel_node.h
+++ b/include/behaviortree_cpp_v3/controls/parallel_node.h
@@ -41,12 +41,12 @@ class ParallelNode : public ControlNode
 
     unsigned int thresholdM();
     unsigned int thresholdFM();
-    void setThresholdM(unsigned int threshold_M);
-    void setThresholdFM(unsigned int threshold_M);
+    void setThresholdM(int threshold_M);
+    void setThresholdFM(int threshold_M);
 
   private:
-    unsigned int success_threshold_;
-    unsigned int failure_threshold_;
+    int success_threshold_;
+    int failure_threshold_;
 
     std::set<int> skip_list_;
 


### PR DESCRIPTION
This is a modification to the `ParallelNode` control to allow negative success threshold and failure threshold values that act like the negative index in python arrays to count backwards from the child node count. This allows for thresholds to be dynamic so that additions or removals of child nodes in an XML file will not require an update to thresholds if the intention is to have threshold values based on the total number of children.