### PR TITLE
Added pure CMake action to PR checks

### DIFF
--- a/.github/workflows/build_vanilla.yml
+++ b/.github/workflows/build_vanilla.yml
@@ -1,6 +1,6 @@
 name: CMake Build Matrix
 
-on: [push]
+on: [push, pull_request]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,4 +1,4 @@
-name: CMake Build Matrix
+name: cmake
 
 on: [push, pull_request]
 


### PR DESCRIPTION
I noticed in #358 that the pure CMake Action wasn't being included in the PR checks. Failures to this Action weren't showing as ❌ in PRs, which can lead to accidental regressions.

This PR adds the CMake Action as a PR check. It also renames the Action to `cmake` to follow the pattern with `ros1` and `ros2`.