### PR TITLE
Revisit export configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,7 +279,7 @@ endif()
 # INSTALL
 
 INSTALL(TARGETS ${BEHAVIOR_TREE_LIBRARY}
-    EXPORT BehaviorTreeV3Config
+    EXPORT ${PROJECT_NAME}Targets
     ARCHIVE DESTINATION ${BEHAVIOR_TREE_LIB_DESTINATION}
     LIBRARY DESTINATION ${BEHAVIOR_TREE_LIB_DESTINATION}
     RUNTIME DESTINATION ${BEHAVIOR_TREE_BIN_DESTINATION}
@@ -289,15 +289,36 @@ INSTALL( DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
     DESTINATION ${BEHAVIOR_TREE_INC_DESTINATION}
     FILES_MATCHING PATTERN "*.h*")
 
-install(EXPORT BehaviorTreeV3Config
-    DESTINATION "${BEHAVIOR_TREE_LIB_DESTINATION}/BehaviorTreeV3/cmake"
-    NAMESPACE BT::)
-
-export(TARGETS ${PROJECT_NAME}
+install(EXPORT ${PROJECT_NAME}Targets
+    FILE "${PROJECT_NAME}Targets.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
     NAMESPACE BT::
-    FILE "${CMAKE_CURRENT_BINARY_DIR}/BehaviorTreeV3Config.cmake")
+    )
 
 export(PACKAGE ${PROJECT_NAME})
+
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+)
+
+# This requires to declare to project version in the project() macro
+
+#write_basic_package_version_file(
+#  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+#  VERSION ${PROJECT_VERSION}
+#  COMPATIBILITY AnyNewerVersion
+#)
+
+install(
+  FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    #    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+)
 
 ######################################################
 # EXAMPLES and TOOLS

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+
+set(@PROJECT_NAME@_TARGETS "BT::@BEHAVIOR_TREE_LIBRARY@")
+
+check_required_components(@PROJECT_NAME@)


### PR DESCRIPTION
While building ROS 2 from source together with Nav2 and BT I've encountered a couple issues with BT.

- First the `Config.cmake` file exported was named `BehaviorTreeV3Config.cmake` whereas, the project being named `behaviortree_cpp_v3`, one would expect the file to be `behaviortree_cpp_v3Config.cmake`.
- Second, for some reason I would never enter the `if(ament_cmake_FOUND)` conditional block, thus the `behaviortree_cpp_v3_TARGETS` would never be automatically exported by `ament` and thus never found when BT is included in another project; `ament_target_dependencies` depends on it to properly set up the interfaces.

This PR adresses both issues by revisiting the project export configuration following the [tutorial on CMake website](https://cmake.org/cmake/help/latest/guide/tutorial/Adding%20Export%20Configuration.html).

Marking as draft since I've only tested my use case and this may break others.