### PR TITLE
Fix pseudo-code typo

### DIFF
--- a/docs/asynchronous_nodes.md
+++ b/docs/asynchronous_nodes.md
@@ -255,7 +255,7 @@ The corresponding **pseudo-code** implementation will look like this:
 class ActionClientNode : public BT::StatefulActionNode
 {
   public:
-    SleepNode(const std::string& name, const BT::NodeConfiguration& config)
+    ActionClientNode(const std::string& name, const BT::NodeConfiguration& config)
       : BT::StatefulActionNode(name, config)
     {}
 


### PR DESCRIPTION

I think the constructor is correct in the below pseudo code section 


![aa](https://user-images.githubusercontent.com/70446214/172069685-65937d02-c162-47e6-a450-d319aebe902e.png)
