### PR TITLE
add option to conditionally build manual selector node

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ option(BUILD_SAMPLES    "Build sample nodes" ON)
 option(BUILD_UNIT_TESTS "Build the unit tests" ON)
 option(BUILD_TOOLS "Build commandline tools" ON)
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+option(BUILD_MANUAL_SELECTOR "Build manual selector node" ON)
 option(ENABLE_COROUTINES "Enable boost coroutines" ON)
 
 #---- Include boost to add coroutines ----
@@ -166,9 +167,9 @@ list(APPEND BT_SOURCE
     3rdparty/minitrace/minitrace.cpp
     )
 
-find_package(Curses QUIET)
+if(BUILD_MANUAL_SELECTOR)
+    find_package(Curses REQUIRED)
 
-if(CURSES_FOUND)
     list(APPEND BT_SOURCE
         src/controls/manual_node.cpp
         )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,13 +168,16 @@ list(APPEND BT_SOURCE
     )
 
 if(BUILD_MANUAL_SELECTOR)
-    find_package(Curses REQUIRED)
-
-    list(APPEND BT_SOURCE
-        src/controls/manual_node.cpp
-        )
-    list(APPEND BEHAVIOR_TREE_PUBLIC_LIBRARIES ${CURSES_LIBRARIES})
-    add_definitions(-DNCURSES_FOUND)
+    find_package(Curses QUIET)
+    if(CURSES_FOUND)
+        list(APPEND BT_SOURCE
+            src/controls/manual_node.cpp
+            )
+        list(APPEND BEHAVIOR_TREE_PUBLIC_LIBRARIES ${CURSES_LIBRARIES})
+        add_definitions(-DNCURSES_FOUND)
+    else()
+        message(WARNING "NCurses NOT found. Skipping the build of manual selector node.")
+    endif()
 endif()
 
 


### PR DESCRIPTION
Currently, the code looks whether `ncurses` is found and if that's the case, it tries to build the manual selector node.
This PR adds an explicit option to enable/disable building this node.

Besides giving more control on the dependencies, this simplifies cross-compilation procedures for example when building this package in conan (see here https://github.com/conan-io/conan-center-index/blob/master/recipes/behaviortree.cpp/all/conanfile.py) 

Conan requires that all dependencies that will be "searched" (via `find_package`) are listed as requirements in the conanfile and it does not play well with optional dependencies that are not controlled via CMake options.
In particular, without my change, the code implicitly required the cross-compilation of ncurses.
 - in order to specify `ncurses` as a dependency in the conanfile it is required to cross-compile it.
 - if a user didn't specify `ncurses` as a dependency, `find_package(Curses QUIET)` could still find an x86_64 version if this was present in the OS (e.g. ubuntu desktop) thus linking it with the library and obviously failing the compilation as the library format was incompatible.



Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>