### PR TITLE
Shutdown zmq context after joining the server thread and flushing

### DIFF
--- a/src/loggers/bt_zmq_publisher.cpp
+++ b/src/loggers/bt_zmq_publisher.cpp
@@ -91,12 +91,12 @@ PublisherZMQ::PublisherZMQ(const BT::Tree& tree,
 PublisherZMQ::~PublisherZMQ()
 {
     active_server_ = false;
-    zmq_->context.shutdown();
     if (thread_.joinable())
     {
         thread_.join();
     }
     flush();
+    zmq_->context.shutdown();
     delete zmq_;
     ref_count = false;
 }


### PR DESCRIPTION
Fix: #375

I kept getting this exception, `zmq_->publisher` and `zmq_->server` are trying to send data after the context is shutdown
