### PR TITLE
fix(README): change find_package() instruction for BT external usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ project(hello_BT)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-find_package(BehaviorTreeV3)
+find_package(behaviortree_cpp_v3)
 
 add_executable(${PROJECT_NAME} "hello_BT.cpp")
 target_link_libraries(${PROJECT_NAME} BT::behaviortree_cpp_v3)


### PR DESCRIPTION
Modified README instruction in order to successfully use BT in an external project.

Related to #366 .