### PR TITLE
Added ros_environment dependency to make sure ROS_VERSION is initialized

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,8 @@
   <author>Michele Colledanchise</author>
   <author>Davide Faconti</author>
 
+  <build_depend>ros_environment</build_depend>
+
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
   <depend condition="$ROS_VERSION == 1">roslib</depend>
 
@@ -23,7 +25,7 @@
   <depend>boost</depend>
   <depend>libzmq3-dev</depend>
   <depend>libncurses-dev</depend>
-  
+
   <test_depend condition="$ROS_VERSION == 2">ament_cmake_gtest</test_depend>
 
   <export>


### PR DESCRIPTION
Found this while building ROS2 galactic from source - looks like you need to add a build_depend to ros_environment, otherwise there's no guarantee that ROS_VERSION exists when package.xml is processed.