### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,18 @@ You can easily install the package with the command
 If you want to compile it with catkin, you __must__ include this package 
 to your catkin workspace.
 
+## Installing BehaviorTree.CPP (vcpkg)
+
+Alternatively, you can build and install behaviortree-cpp using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install behaviortree-cpp
+
+The behaviortree-cpp port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 # Acknowledgement
 
 This library was initially developed at  **Eurecat - https://eurecat.org/en/** (main author, Davide Faconti) in a joint effort


### PR DESCRIPTION
`BehaviorTree.CPP` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `BehaviorTree.CPP` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `BehaviorTree.CPP`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/behaviortree-cpp/portfile.cmake). We try to keep the library maintained as close as possible to the original library.😊


