### PR TITLE
Fix incorrect registration of behavior trees containing faulty XML

### DIFF
--- a/include/behaviortree_cpp_v3/xml_parsing.h
+++ b/include/behaviortree_cpp_v3/xml_parsing.h
@@ -36,6 +36,9 @@ private:
   Pimpl* _p;
 };
 
+void VerifyXML(const std::string& xml_text,
+               const std::unordered_map<std::string, NodeType>& registered_nodes);
+
 std::string writeTreeNodesModelXML(const BehaviorTreeFactory& factory,
                                    bool include_builtin = false);
 

--- a/include/behaviortree_cpp_v3/xml_parsing.h
+++ b/include/behaviortree_cpp_v3/xml_parsing.h
@@ -36,9 +36,6 @@ private:
   Pimpl* _p;
 };
 
-void VerifyXML(const std::string& xml_text,
-               const std::unordered_map<std::string, NodeType>& registered_nodes);
-
 std::string writeTreeNodesModelXML(const BehaviorTreeFactory& factory,
                                    bool include_builtin = false);
 

--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -46,6 +46,197 @@ auto StrEqual = [](const char* str1, const char* str2) -> bool {
   return strcmp(str1, str2) == 0;
 };
 
+namespace
+{
+/**
+ * @brief Throws a BT::RuntimeError with an error message a line number and some text
+ */
+void ThrowError(int line_num, const std::string& text) {
+    char buffer[256];
+    sprintf(buffer, "Error at line %d: -> %s", line_num, text.c_str());
+    throw BT::RuntimeError( buffer );
+}
+
+/**
+ * @brief Returns the number of children under an XML node
+ */
+int ChildrenCount(const XMLElement* parent_node) {
+    int count = 0;
+    for (auto node = parent_node->FirstChildElement(); node != nullptr;
+            node = node->NextSiblingElement())
+    {
+        count++;
+    }
+    return count;
+}
+
+
+/**
+ * @brief Recursively enforces that the attributes of an XML node and all its child nodes are all correct.
+ * @throw BT::RuntimeError if an error was found.
+ */
+void verifyXMLRecursively(const XMLElement* node,
+                          const std::unordered_map<std::string, BT::NodeType>& registered_nodes)
+{
+    const int children_count = ChildrenCount(node);
+    const char* name = node->Name();
+    if (StrEqual(name, "Decorator"))
+    {
+        if (children_count != 1)
+        {
+            ThrowError(node->GetLineNum(),
+                        "The node <Decorator> must have exactly 1 child");
+        }
+        if (!node->Attribute("ID"))
+        {
+            ThrowError(node->GetLineNum(),
+                        "The node <Decorator> must have the attribute [ID]");
+        }
+    }
+    else if (StrEqual(name, "Action"))
+    {
+        if (children_count != 0)
+        {
+            ThrowError(node->GetLineNum(),
+                        "The node <Action> must not have any child");
+        }
+        if (!node->Attribute("ID"))
+        {
+            ThrowError(node->GetLineNum(),
+                        "The node <Action> must have the attribute [ID]");
+        }
+    }
+    else if (StrEqual(name, "Condition"))
+    {
+        if (children_count != 0)
+        {
+            ThrowError(node->GetLineNum(),
+                        "The node <Condition> must not have any child");
+        }
+        if (!node->Attribute("ID"))
+        {
+            ThrowError(node->GetLineNum(),
+                        "The node <Condition> must have the attribute [ID]");
+        }
+    }
+    else if (StrEqual(name, "Control"))
+    {
+        if (children_count == 0)
+        {
+            ThrowError(node->GetLineNum(),
+                        "The node <Control> must have at least 1 child");
+        }
+        if (!node->Attribute("ID"))
+        {
+            ThrowError(node->GetLineNum(),
+                        "The node <Control> must have the attribute [ID]");
+        }
+    }
+    else if (StrEqual(name, "Sequence") ||
+                StrEqual(name, "SequenceStar") ||
+                StrEqual(name, "Fallback") )
+    {
+        if (children_count == 0)
+        {
+            ThrowError(node->GetLineNum(),
+                        "A Control node must have at least 1 child");
+        }
+    }
+    else if (StrEqual(name, "SubTree"))
+    {
+        auto child = node->FirstChildElement();
+
+        if (child)
+        {
+            if (StrEqual(child->Name(), "remap"))
+            {
+                ThrowError(node->GetLineNum(), "<remap> was deprecated");
+            }
+            else{
+                ThrowError(node->GetLineNum(), "<SubTree> should not have any child");
+            }
+        }
+
+        if (!node->Attribute("ID"))
+        {
+            ThrowError(node->GetLineNum(),
+                        "The node <SubTree> must have the attribute [ID]");
+        }
+    }
+    else if (StrEqual(name, "BehaviorTree"))
+    {
+        if (children_count != 1)
+        {
+            ThrowError(node->GetLineNum(), "The node <BehaviorTree> must have exactly 1 child");
+        }
+    }
+    else
+    {
+        // search in the factory and the list of subtrees
+        const auto search = registered_nodes.find(name);
+        bool found = ( search != registered_nodes.end() );
+        if (!found)
+        {
+            ThrowError(node->GetLineNum(),
+                        std::string("Node not recognized: ") + name);
+        }
+
+        if (search->second == NodeType::DECORATOR)
+        {
+            if (children_count != 1)
+            {
+                ThrowError(node->GetLineNum(),
+                        std::string("The node <") + name + "> must have exactly 1 child");
+            }
+        }
+    }
+    //recursion
+    if (StrEqual(name, "SubTree") == false)
+    {
+        for (auto child = node->FirstChildElement(); child != nullptr;
+                child = child->NextSiblingElement())
+        {
+            verifyXMLRecursively(child, registered_nodes);
+        }
+    }
+}
+
+void verifyTreeNodesModel(const XMLElement* xml_root)
+{
+  auto models_root = xml_root->FirstChildElement("TreeNodesModel");
+  auto meta_sibling =
+      models_root ? models_root->NextSiblingElement("TreeNodesModel") : nullptr;
+
+  if (meta_sibling)
+  {
+    ThrowError(meta_sibling->GetLineNum(), " Only a single node <TreeNodesModel> is "
+                                           "supported");
+  }
+  if (models_root)
+  {
+    // not having a MetaModel is not an error. But consider that the
+    // Graphical editor needs it.
+    for (auto node = xml_root->FirstChildElement(); node != nullptr;
+         node = node->NextSiblingElement())
+    {
+      const char* name = node->Name();
+      if (StrEqual(name, "Action") || StrEqual(name, "Decorator") ||
+          StrEqual(name, "SubTree") || StrEqual(name, "Condition") ||
+          StrEqual(name, "Control"))
+      {
+        const char* ID = node->Attribute("ID");
+        if (!ID)
+        {
+          ThrowError(node->GetLineNum(), "Error at line %d: -> The attribute "
+                                         "[ID] is "
+                                         "mandatory");
+        }
+      }
+    }
+  }
+}
+}
+
 struct XMLParser::Pimpl
 {
   TreeNode::Ptr createNodeFromXML(const XMLElement* element,
@@ -199,250 +390,56 @@ void XMLParser::Pimpl::loadDocImpl(tinyxml2::XMLDocument* doc, bool add_includes
     current_path = previous_path;
   }
 
-  for (auto bt_node = xml_root->FirstChildElement("BehaviorTree"); bt_node != nullptr;
-       bt_node = bt_node->NextSiblingElement("BehaviorTree"))
-  {
-    std::string tree_name;
-    if (bt_node->Attribute("ID"))
+    // Validate the TreeNodesModel, if it is present in the XML
+    verifyTreeNodesModel(xml_root);
+
+    // Collect the names of all nodes registered with the behavior tree factory
+    std::unordered_map<std::string, BT::NodeType> registered_nodes;
+    for( const auto& it: factory.manifests())
     {
-      tree_name = bt_node->Attribute("ID");
+        registered_nodes.insert({it.first, it.second.type});
     }
-    else
+
+    // Validate each BehaviorTree within the XML
+    for (auto bt_node = xml_root->FirstChildElement("BehaviorTree");
+            bt_node != nullptr;
+            bt_node = bt_node->NextSiblingElement("BehaviorTree"))
     {
-      tree_name = "BehaviorTree_" + std::to_string(suffix_count++);
+        std::string tree_name;
+        if (bt_node->Attribute("ID"))
+        {
+            tree_name = bt_node->Attribute("ID");
+        }
+        else{
+            tree_name = "BehaviorTree_" + std::to_string( suffix_count++ );
+        }
+
+        // Validate the structure of the BehaviorTree node
+        try
+        {
+            verifyXMLRecursively(bt_node, registered_nodes);
+        }
+        catch(const std::exception& e)
+        {
+            continue;
+        }
+
+        // Only add this behavior tree to the list of registered behavior trees if its XML representation is valid.
+        tree_roots.insert( {tree_name, bt_node} );
     }
-    tree_roots.insert({tree_name, bt_node});
-  }
 
-  std::unordered_map<std::string, BT::NodeType> registered_nodes;
-  XMLPrinter printer;
-  doc->Print(&printer);
-  auto xml_text = std::string(printer.CStr(), size_t(printer.CStrSize() - 1));
-
-  for (const auto& it : factory.manifests())
-  {
-    registered_nodes.insert({it.first, it.second.type});
-  }
-  for (const auto& it : tree_roots)
-  {
-    registered_nodes.insert({it.first, NodeType::SUBTREE});
-  }
-
-  VerifyXML(xml_text, registered_nodes);
+    for( const auto& it: tree_roots)
+    {
+        registered_nodes.insert({it.first, NodeType::SUBTREE});
+    }
+    
+    //-------------------------------------------------
+    for (auto bt_root = xml_root->FirstChildElement("BehaviorTree"); bt_root != nullptr;
+         bt_root = bt_root->NextSiblingElement("BehaviorTree"))
+    {
+        verifyXMLRecursively(bt_root, registered_nodes);
+    }
 }
-
-void VerifyXML(const std::string& xml_text,
-               const std::unordered_map<std::string, BT::NodeType>& registered_nodes)
-{
-  tinyxml2::XMLDocument doc;
-  auto xml_error = doc.Parse(xml_text.c_str(), xml_text.size());
-  if (xml_error)
-  {
-    char buffer[200];
-    sprintf(buffer, "Error parsing the XML: %s", doc.ErrorName());
-    throw RuntimeError(buffer);
-  }
-
-  //-------- Helper functions (lambdas) -----------------
-  auto ThrowError = [&](int line_num, const std::string& text) {
-    char buffer[256];
-    sprintf(buffer, "Error at line %d: -> %s", line_num, text.c_str());
-    throw RuntimeError(buffer);
-  };
-
-  auto ChildrenCount = [](const XMLElement* parent_node) {
-    int count = 0;
-    for (auto node = parent_node->FirstChildElement(); node != nullptr;
-         node = node->NextSiblingElement())
-    {
-      count++;
-    }
-    return count;
-  };
-  //-----------------------------
-
-  const XMLElement* xml_root = doc.RootElement();
-
-  if (!xml_root || !StrEqual(xml_root->Name(), "root"))
-  {
-    throw RuntimeError("The XML must have a root node called <root>");
-  }
-  //-------------------------------------------------
-  auto models_root = xml_root->FirstChildElement("TreeNodesModel");
-  auto meta_sibling =
-      models_root ? models_root->NextSiblingElement("TreeNodesModel") : nullptr;
-
-  if (meta_sibling)
-  {
-    ThrowError(meta_sibling->GetLineNum(), " Only a single node <TreeNodesModel> is "
-                                           "supported");
-  }
-  if (models_root)
-  {
-    // not having a MetaModel is not an error. But consider that the
-    // Graphical editor needs it.
-    for (auto node = xml_root->FirstChildElement(); node != nullptr;
-         node = node->NextSiblingElement())
-    {
-      const char* name = node->Name();
-      if (StrEqual(name, "Action") || StrEqual(name, "Decorator") ||
-          StrEqual(name, "SubTree") || StrEqual(name, "Condition") ||
-          StrEqual(name, "Control"))
-      {
-        const char* ID = node->Attribute("ID");
-        if (!ID)
-        {
-          ThrowError(node->GetLineNum(), "Error at line %d: -> The attribute "
-                                         "[ID] is "
-                                         "mandatory");
-        }
-      }
-    }
-  }
-  //-------------------------------------------------
-
-  // function to be called recursively
-  std::function<void(const XMLElement*)> recursiveStep;
-
-  recursiveStep = [&](const XMLElement* node) {
-    const int children_count = ChildrenCount(node);
-    const char* name = node->Name();
-    if (StrEqual(name, "Decorator"))
-    {
-      if (children_count != 1)
-      {
-        ThrowError(node->GetLineNum(), "The node <Decorator> must have exactly 1 "
-                                       "child");
-      }
-      if (!node->Attribute("ID"))
-      {
-        ThrowError(node->GetLineNum(), "The node <Decorator> must have the "
-                                       "attribute [ID]");
-      }
-    }
-    else if (StrEqual(name, "Action"))
-    {
-      if (children_count != 0)
-      {
-        ThrowError(node->GetLineNum(), "The node <Action> must not have any "
-                                       "child");
-      }
-      if (!node->Attribute("ID"))
-      {
-        ThrowError(node->GetLineNum(), "The node <Action> must have the "
-                                       "attribute [ID]");
-      }
-    }
-    else if (StrEqual(name, "Condition"))
-    {
-      if (children_count != 0)
-      {
-        ThrowError(node->GetLineNum(), "The node <Condition> must not have any "
-                                       "child");
-      }
-      if (!node->Attribute("ID"))
-      {
-        ThrowError(node->GetLineNum(), "The node <Condition> must have the "
-                                       "attribute [ID]");
-      }
-    }
-    else if (StrEqual(name, "Control"))
-    {
-      if (children_count == 0)
-      {
-        ThrowError(node->GetLineNum(), "The node <Control> must have at least 1 "
-                                       "child");
-      }
-      if (!node->Attribute("ID"))
-      {
-        ThrowError(node->GetLineNum(), "The node <Control> must have the "
-                                       "attribute [ID]");
-      }
-    }
-    else if (StrEqual(name, "Sequence") || StrEqual(name, "SequenceStar") ||
-             StrEqual(name, "Fallback"))
-    {
-      if (children_count == 0)
-      {
-        ThrowError(node->GetLineNum(), "A Control node must have at least 1 "
-                                       "child");
-      }
-    }
-    else if (StrEqual(name, "SubTree"))
-    {
-      auto child = node->FirstChildElement();
-
-      if (child)
-      {
-        if (StrEqual(child->Name(), "remap"))
-        {
-          ThrowError(node->GetLineNum(), "<remap> was deprecated");
-        }
-        else
-        {
-          ThrowError(node->GetLineNum(), "<SubTree> should not have any child");
-        }
-      }
-
-      if (!node->Attribute("ID"))
-      {
-        ThrowError(node->GetLineNum(), "The node <SubTree> must have the "
-                                       "attribute [ID]");
-      }
-    }
-    else
-    {
-      // search in the factory and the list of subtrees
-      const auto search = registered_nodes.find(name);
-      bool found = (search != registered_nodes.end());
-      if (!found)
-      {
-        ThrowError(node->GetLineNum(), std::string("Node not recognized: ") + name);
-      }
-
-      if (search->second == NodeType::DECORATOR)
-      {
-        if (children_count != 1)
-        {
-          ThrowError(node->GetLineNum(),
-                     std::string("The node <") + name + "> must have exactly 1 child");
-        }
-      }
-    }
-    //recursion
-    if (StrEqual(name, "SubTree") == false)
-    {
-      for (auto child = node->FirstChildElement(); child != nullptr;
-           child = child->NextSiblingElement())
-      {
-        recursiveStep(child);
-      }
-    }
-  };
-
-  std::vector<std::string> tree_names;
-  int tree_count = 0;
-
-  for (auto bt_root = xml_root->FirstChildElement("BehaviorTree"); bt_root != nullptr;
-       bt_root = bt_root->NextSiblingElement("BehaviorTree"))
-  {
-    tree_count++;
-    if (bt_root->Attribute("ID"))
-    {
-      tree_names.emplace_back(bt_root->Attribute("ID"));
-    }
-    if (ChildrenCount(bt_root) != 1)
-    {
-      ThrowError(bt_root->GetLineNum(), "The node <BehaviorTree> must have exactly "
-                                        "1 child");
-    }
-    else
-    {
-      recursiveStep(bt_root->FirstChildElement());
-    }
-  }
-}
-
 Tree XMLParser::instantiateTree(const Blackboard::Ptr& root_blackboard,
                                 std::string main_tree_to_execute)
 {

--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -213,7 +213,7 @@ void XMLParser::Pimpl::loadDocImpl(tinyxml2::XMLDocument* doc, bool add_includes
   // Verify the validity of the XML before adding any behavior trees to the parser's list of registered trees
   VerifyXML(xml_text, registered_nodes);
 
-  // Validate each BehaviorTree within the XML
+  // Register each BehaviorTree within the XML
   for (auto bt_node = xml_root->FirstChildElement("BehaviorTree"); bt_node != nullptr;
        bt_node = bt_node->NextSiblingElement("BehaviorTree"))
   {

--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -51,154 +51,145 @@ namespace
 /**
  * @brief Throws a BT::RuntimeError with an error message a line number and some text
  */
-void ThrowError(int line_num, const std::string& text) {
-    char buffer[256];
-    sprintf(buffer, "Error at line %d: -> %s", line_num, text.c_str());
-    throw BT::RuntimeError( buffer );
+void ThrowError(int line_num, const std::string& text)
+{
+  char buffer[256];
+  sprintf(buffer, "Error at line %d: -> %s", line_num, text.c_str());
+  throw BT::RuntimeError(buffer);
 }
 
 /**
  * @brief Returns the number of children under an XML node
  */
-int ChildrenCount(const XMLElement* parent_node) {
-    int count = 0;
-    for (auto node = parent_node->FirstChildElement(); node != nullptr;
-            node = node->NextSiblingElement())
-    {
-        count++;
-    }
-    return count;
+int ChildrenCount(const XMLElement* parent_node)
+{
+  int count = 0;
+  for (auto node = parent_node->FirstChildElement(); node != nullptr;
+       node = node->NextSiblingElement())
+  {
+    count++;
+  }
+  return count;
 }
-
 
 /**
  * @brief Recursively enforces that the attributes of an XML node and all its child nodes are all correct.
  * @throw BT::RuntimeError if an error was found.
  */
-void verifyXMLRecursively(const XMLElement* node,
-                          const std::unordered_map<std::string, BT::NodeType>& registered_nodes)
+void verifyXMLRecursively(
+    const XMLElement* node,
+    const std::unordered_map<std::string, BT::NodeType>& registered_nodes)
 {
-    const int children_count = ChildrenCount(node);
-    const char* name = node->Name();
-    if (StrEqual(name, "Decorator"))
+  const int children_count = ChildrenCount(node);
+  const char* name = node->Name();
+  if (StrEqual(name, "Decorator"))
+  {
+    if (children_count != 1)
     {
-        if (children_count != 1)
-        {
-            ThrowError(node->GetLineNum(),
-                        "The node <Decorator> must have exactly 1 child");
-        }
-        if (!node->Attribute("ID"))
-        {
-            ThrowError(node->GetLineNum(),
-                        "The node <Decorator> must have the attribute [ID]");
-        }
+      ThrowError(node->GetLineNum(), "The node <Decorator> must have exactly 1 child");
     }
-    else if (StrEqual(name, "Action"))
+    if (!node->Attribute("ID"))
     {
-        if (children_count != 0)
-        {
-            ThrowError(node->GetLineNum(),
-                        "The node <Action> must not have any child");
-        }
-        if (!node->Attribute("ID"))
-        {
-            ThrowError(node->GetLineNum(),
-                        "The node <Action> must have the attribute [ID]");
-        }
+      ThrowError(node->GetLineNum(), "The node <Decorator> must have the attribute [ID]");
     }
-    else if (StrEqual(name, "Condition"))
+  }
+  else if (StrEqual(name, "Action"))
+  {
+    if (children_count != 0)
     {
-        if (children_count != 0)
-        {
-            ThrowError(node->GetLineNum(),
-                        "The node <Condition> must not have any child");
-        }
-        if (!node->Attribute("ID"))
-        {
-            ThrowError(node->GetLineNum(),
-                        "The node <Condition> must have the attribute [ID]");
-        }
+      ThrowError(node->GetLineNum(), "The node <Action> must not have any child");
     }
-    else if (StrEqual(name, "Control"))
+    if (!node->Attribute("ID"))
     {
-        if (children_count == 0)
-        {
-            ThrowError(node->GetLineNum(),
-                        "The node <Control> must have at least 1 child");
-        }
-        if (!node->Attribute("ID"))
-        {
-            ThrowError(node->GetLineNum(),
-                        "The node <Control> must have the attribute [ID]");
-        }
+      ThrowError(node->GetLineNum(), "The node <Action> must have the attribute [ID]");
     }
-    else if (StrEqual(name, "Sequence") ||
-                StrEqual(name, "SequenceStar") ||
-                StrEqual(name, "Fallback") )
+  }
+  else if (StrEqual(name, "Condition"))
+  {
+    if (children_count != 0)
     {
-        if (children_count == 0)
-        {
-            ThrowError(node->GetLineNum(),
-                        "A Control node must have at least 1 child");
-        }
+      ThrowError(node->GetLineNum(), "The node <Condition> must not have any child");
     }
-    else if (StrEqual(name, "SubTree"))
+    if (!node->Attribute("ID"))
     {
-        auto child = node->FirstChildElement();
+      ThrowError(node->GetLineNum(), "The node <Condition> must have the attribute [ID]");
+    }
+  }
+  else if (StrEqual(name, "Control"))
+  {
+    if (children_count == 0)
+    {
+      ThrowError(node->GetLineNum(), "The node <Control> must have at least 1 child");
+    }
+    if (!node->Attribute("ID"))
+    {
+      ThrowError(node->GetLineNum(), "The node <Control> must have the attribute [ID]");
+    }
+  }
+  else if (StrEqual(name, "Sequence") || StrEqual(name, "SequenceStar") ||
+           StrEqual(name, "Fallback"))
+  {
+    if (children_count == 0)
+    {
+      ThrowError(node->GetLineNum(), "A Control node must have at least 1 child");
+    }
+  }
+  else if (StrEqual(name, "SubTree"))
+  {
+    auto child = node->FirstChildElement();
 
-        if (child)
-        {
-            if (StrEqual(child->Name(), "remap"))
-            {
-                ThrowError(node->GetLineNum(), "<remap> was deprecated");
-            }
-            else{
-                ThrowError(node->GetLineNum(), "<SubTree> should not have any child");
-            }
-        }
+    if (child)
+    {
+      if (StrEqual(child->Name(), "remap"))
+      {
+        ThrowError(node->GetLineNum(), "<remap> was deprecated");
+      }
+      else
+      {
+        ThrowError(node->GetLineNum(), "<SubTree> should not have any child");
+      }
+    }
 
-        if (!node->Attribute("ID"))
-        {
-            ThrowError(node->GetLineNum(),
-                        "The node <SubTree> must have the attribute [ID]");
-        }
-    }
-    else if (StrEqual(name, "BehaviorTree"))
+    if (!node->Attribute("ID"))
     {
-        if (children_count != 1)
-        {
-            ThrowError(node->GetLineNum(), "The node <BehaviorTree> must have exactly 1 child");
-        }
+      ThrowError(node->GetLineNum(), "The node <SubTree> must have the attribute [ID]");
     }
-    else
+  }
+  else if (StrEqual(name, "BehaviorTree"))
+  {
+    if (children_count != 1)
     {
-        // search in the factory and the list of subtrees
-        const auto search = registered_nodes.find(name);
-        bool found = ( search != registered_nodes.end() );
-        if (!found)
-        {
-            ThrowError(node->GetLineNum(),
-                        std::string("Node not recognized: ") + name);
-        }
+      ThrowError(node->GetLineNum(), "The node <BehaviorTree> must have exactly 1 child");
+    }
+  }
+  else
+  {
+    // search in the factory and the list of subtrees
+    const auto search = registered_nodes.find(name);
+    bool found = (search != registered_nodes.end());
+    if (!found)
+    {
+      ThrowError(node->GetLineNum(), std::string("Node not recognized: ") + name);
+    }
 
-        if (search->second == NodeType::DECORATOR)
-        {
-            if (children_count != 1)
-            {
-                ThrowError(node->GetLineNum(),
-                        std::string("The node <") + name + "> must have exactly 1 child");
-            }
-        }
-    }
-    //recursion
-    if (StrEqual(name, "SubTree") == false)
+    if (search->second == NodeType::DECORATOR)
     {
-        for (auto child = node->FirstChildElement(); child != nullptr;
-                child = child->NextSiblingElement())
-        {
-            verifyXMLRecursively(child, registered_nodes);
-        }
+      if (children_count != 1)
+      {
+        ThrowError(node->GetLineNum(),
+                   std::string("The node <") + name + "> must have exactly 1 child");
+      }
     }
+  }
+  //recursion
+  if (StrEqual(name, "SubTree") == false)
+  {
+    for (auto child = node->FirstChildElement(); child != nullptr;
+         child = child->NextSiblingElement())
+    {
+      verifyXMLRecursively(child, registered_nodes);
+    }
+  }
 }
 
 void verifyTreeNodesModel(const XMLElement* xml_root)
@@ -235,7 +226,7 @@ void verifyTreeNodesModel(const XMLElement* xml_root)
     }
   }
 }
-}
+}   // namespace
 
 struct XMLParser::Pimpl
 {
@@ -390,56 +381,57 @@ void XMLParser::Pimpl::loadDocImpl(tinyxml2::XMLDocument* doc, bool add_includes
     current_path = previous_path;
   }
 
-    // Validate the TreeNodesModel, if it is present in the XML
-    verifyTreeNodesModel(xml_root);
+  // Validate the TreeNodesModel, if it is present in the XML
+  verifyTreeNodesModel(xml_root);
 
-    // Collect the names of all nodes registered with the behavior tree factory
-    std::unordered_map<std::string, BT::NodeType> registered_nodes;
-    for( const auto& it: factory.manifests())
+  // Collect the names of all nodes registered with the behavior tree factory
+  std::unordered_map<std::string, BT::NodeType> registered_nodes;
+  for (const auto& it : factory.manifests())
+  {
+    registered_nodes.insert({it.first, it.second.type});
+  }
+
+  // Validate each BehaviorTree within the XML
+  for (auto bt_node = xml_root->FirstChildElement("BehaviorTree"); bt_node != nullptr;
+       bt_node = bt_node->NextSiblingElement("BehaviorTree"))
+  {
+    std::string tree_name;
+    if (bt_node->Attribute("ID"))
     {
-        registered_nodes.insert({it.first, it.second.type});
+      tree_name = bt_node->Attribute("ID");
+    }
+    else
+    {
+      tree_name = "BehaviorTree_" + std::to_string(suffix_count++);
     }
 
-    // Validate each BehaviorTree within the XML
-    for (auto bt_node = xml_root->FirstChildElement("BehaviorTree");
-            bt_node != nullptr;
-            bt_node = bt_node->NextSiblingElement("BehaviorTree"))
+    // Validate the structure of the BehaviorTree node
+    try
     {
-        std::string tree_name;
-        if (bt_node->Attribute("ID"))
-        {
-            tree_name = bt_node->Attribute("ID");
-        }
-        else{
-            tree_name = "BehaviorTree_" + std::to_string( suffix_count++ );
-        }
-
-        // Validate the structure of the BehaviorTree node
-        try
-        {
-            verifyXMLRecursively(bt_node, registered_nodes);
-        }
-        catch(const std::exception& e)
-        {
-            continue;
-        }
-
-        // Only add this behavior tree to the list of registered behavior trees if its XML representation is valid.
-        tree_roots.insert( {tree_name, bt_node} );
+      verifyXMLRecursively(bt_node, registered_nodes);
+    }
+    catch (const std::exception& e)
+    {
+      continue;
     }
 
-    for( const auto& it: tree_roots)
-    {
-        registered_nodes.insert({it.first, NodeType::SUBTREE});
-    }
-    
-    //-------------------------------------------------
-    for (auto bt_root = xml_root->FirstChildElement("BehaviorTree"); bt_root != nullptr;
-         bt_root = bt_root->NextSiblingElement("BehaviorTree"))
-    {
-        verifyXMLRecursively(bt_root, registered_nodes);
-    }
+    // Only add this behavior tree to the list of registered behavior trees if its XML representation is valid.
+    tree_roots.insert({tree_name, bt_node});
+  }
+
+  for (const auto& it : tree_roots)
+  {
+    registered_nodes.insert({it.first, NodeType::SUBTREE});
+  }
+
+  //-------------------------------------------------
+  for (auto bt_root = xml_root->FirstChildElement("BehaviorTree"); bt_root != nullptr;
+       bt_root = bt_root->NextSiblingElement("BehaviorTree"))
+  {
+    verifyXMLRecursively(bt_root, registered_nodes);
+  }
 }
+
 Tree XMLParser::instantiateTree(const Blackboard::Ptr& root_blackboard,
                                 std::string main_tree_to_execute)
 {

--- a/tests/gtest_factory.cpp
+++ b/tests/gtest_factory.cpp
@@ -109,6 +109,7 @@ TEST(BehaviorTreeFactory, XMLParsingOrder)
     XMLParser parser(factory);
     parser.loadFromText(xml_text_subtree);
     auto trees = parser.registeredBehaviorTrees();
+    ASSERT_EQ(trees.size(), 2);
     ASSERT_EQ(trees[0], "CrossDoorSubtree");
     ASSERT_EQ(trees[1], "MainTree");
   }
@@ -117,6 +118,7 @@ TEST(BehaviorTreeFactory, XMLParsingOrder)
     parser.loadFromText(xml_text_subtree_part1);
     parser.loadFromText(xml_text_subtree_part2);
     auto trees = parser.registeredBehaviorTrees();
+    ASSERT_EQ(trees.size(), 2);
     ASSERT_EQ(trees[0], "CrossDoorSubtree");
     ASSERT_EQ(trees[1], "MainTree");
   }
@@ -125,6 +127,7 @@ TEST(BehaviorTreeFactory, XMLParsingOrder)
     parser.loadFromText(xml_text_subtree_part2);
     parser.loadFromText(xml_text_subtree_part1);
     auto trees = parser.registeredBehaviorTrees();
+    ASSERT_EQ(trees.size(), 2);
     ASSERT_EQ(trees[0], "CrossDoorSubtree");
     ASSERT_EQ(trees[1], "MainTree");
   }

--- a/tests/gtest_factory.cpp
+++ b/tests/gtest_factory.cpp
@@ -447,3 +447,52 @@ const std::string xml_text_invalid = R"(
     ASSERT_EQ(trees.size(), 1);
     EXPECT_EQ(trees[0], "ValidTree");
 }
+
+TEST(BehaviorTreeFactory, RegisterInvalidXMLBadActionNodeThrows)
+{
+  // GIVEN an invalid tree
+  // This tree contains invalid XML because the action node is missing a trailing `/`.
+  // A valid line would read: <Action ID="AlwaysSuccess" />
+const std::string xml_text_invalid = R"(
+<root>
+    <BehaviorTree ID="InvalidTreeWithBadChild">
+      <Sequence name="seq">
+        <Action ID="AlwaysSuccess" >
+      </Sequence>
+    </BehaviorTree>
+</root> )";
+
+    BehaviorTreeFactory factory;
+    XMLParser parser(factory);
+
+    // WHEN we attempt to load an invalid tree
+    // THEN a RuntimeError exception is thrown
+    EXPECT_THROW(parser.loadFromText(xml_text_invalid), RuntimeError);
+
+    // THEN no tree is registered
+    auto trees = parser.registeredBehaviorTrees();
+    EXPECT_TRUE(trees.empty());
+}
+
+TEST(BehaviorTreeFactory, RegisterInvalidXMLNoRootThrows)
+{
+  // GIVEN an invalid tree
+  // This tree contains invalid XML because it does not have a root node
+const std::string xml_text_invalid = R"(
+    <BehaviorTree ID="InvalidTreeNoRoot">
+      <Sequence name="seq">
+        <Action ID="AlwaysSuccess" />
+      </Sequence>
+    </BehaviorTree> )";
+
+    BehaviorTreeFactory factory;
+    XMLParser parser(factory);
+
+    // WHEN we attempt to load an invalid tree
+    // THEN a RuntimeError exception is thrown
+    EXPECT_THROW(parser.loadFromText(xml_text_invalid), RuntimeError);
+
+    // THEN no tree is registered
+    auto trees = parser.registeredBehaviorTrees();
+    EXPECT_TRUE(trees.empty());
+}


### PR DESCRIPTION
This fixes a problem where a behavior tree containing an invalid structure (for example, a BehaviorTree with less than one child or more than two children) could still be instantiated by the factory, even though the XML parser threw and exception when trying to load it. This was possible because adding a BehaviorTree's name to the list of available behavior trees occurred before the check for the validity of the BehaviorTree's XML.

- Modify XML parsing to add a BehaviorTree node to the list of available trees only if that BehaviorTree is valid.
- Delete unused `tree_names` and `tree_count` variables.
- Extend the unit tests to reflect this error case. These tests fail without the fix in this PR.
- ~~Move XML parsing helper functions into an anonymous namespace so they can be used in more places.~~