### PR TITLE
Add functionality to clear registered behavior trees

### DIFF
--- a/include/behaviortree_cpp_v3/bt_factory.h
+++ b/include/behaviortree_cpp_v3/bt_factory.h
@@ -317,6 +317,11 @@ public:
   std::vector<std::string> registeredBehaviorTrees() const;
 
   /**
+   * @brief Clear previously-registered behavior trees.
+   */
+  void clearRegisteredBehaviorTrees();
+
+  /**
      * @brief instantiateTreeNode creates an instance of a previously registered TreeNode.
      *
      * @param name     name of this particular instance

--- a/include/behaviortree_cpp_v3/bt_parser.h
+++ b/include/behaviortree_cpp_v3/bt_parser.h
@@ -40,6 +40,8 @@ public:
 
   virtual Tree instantiateTree(const Blackboard::Ptr& root_blackboard,
                                std::string tree_name = {}) = 0;
+
+  virtual void clearInternalState() {};
 };
 
 }   // namespace BT

--- a/include/behaviortree_cpp_v3/xml_parsing.h
+++ b/include/behaviortree_cpp_v3/xml_parsing.h
@@ -31,6 +31,8 @@ public:
   Tree instantiateTree(const Blackboard::Ptr& root_blackboard,
                        std::string main_tree_to_execute = {}) override;
 
+  void clearInternalState() override;
+
 private:
   struct Pimpl;
   Pimpl* _p;

--- a/src/bt_factory.cpp
+++ b/src/bt_factory.cpp
@@ -227,12 +227,17 @@ void BehaviorTreeFactory::registerBehaviorTreeFromFile(const std::string& filena
 
 void BehaviorTreeFactory::registerBehaviorTreeFromText(const std::string& xml_text)
 {
-  parser_->loadFromText(xml_text);
+  parser_->loadFromText(xml_text, true /* add_includes */);
 }
 
 std::vector<std::string> BehaviorTreeFactory::registeredBehaviorTrees() const
 {
   return parser_->registeredBehaviorTrees();
+}
+
+void BehaviorTreeFactory::clearRegisteredBehaviorTrees()
+{
+    parser_->clearInternalState();
 }
 
 std::unique_ptr<TreeNode> BehaviorTreeFactory::instantiateTreeNode(

--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -484,6 +484,11 @@ Tree XMLParser::instantiateTree(const Blackboard::Ptr& root_blackboard,
   return output_tree;
 }
 
+void XMLParser::clearInternalState()
+{
+    _p->clear();
+}
+
 TreeNode::Ptr XMLParser::Pimpl::createNodeFromXML(const XMLElement* element,
                                                   const Blackboard::Ptr& blackboard,
                                                   const TreeNode::Ptr& node_parent)

--- a/tests/gtest_factory.cpp
+++ b/tests/gtest_factory.cpp
@@ -407,3 +407,49 @@ TEST(BehaviorTreeFactory, DecoratorWithTwoChildrenThrows)
 
   ASSERT_THROW(factory.createTreeFromText(xml_text), BehaviorTreeException);
 }
+
+TEST(BehaviorTreeFactory, ParserClearRegisteredBehaviorTrees)
+{
+  const std::string tree_xml = R"(
+<root>
+    <BehaviorTree ID="Main">
+        <AlwaysSuccess />
+    </BehaviorTree>
+</root>
+)";
+
+  BehaviorTreeFactory factory;
+  XMLParser parser(factory);
+
+  ASSERT_NO_THROW(parser.loadFromText(tree_xml));
+
+  const auto trees = parser.registeredBehaviorTrees();
+  ASSERT_FALSE(trees.empty());
+
+  parser.clearInternalState();
+
+  const auto trees_after_clear = parser.registeredBehaviorTrees();
+  EXPECT_TRUE(trees_after_clear.empty());
+}
+
+TEST(BehaviorTreeFactory, FactoryClearRegisteredBehaviorTrees)
+{
+  BehaviorTreeFactory factory;
+  const std::string tree_xml = R"(
+<root>
+    <BehaviorTree ID="Main">
+        <AlwaysSuccess />
+    </BehaviorTree>
+</root>
+)";
+
+  ASSERT_NO_THROW(factory.registerBehaviorTreeFromText(tree_xml));
+
+  const auto trees = factory.registeredBehaviorTrees();
+  ASSERT_FALSE(trees.empty());
+
+  factory.clearRegisteredBehaviorTrees();
+
+  const auto trees_after_clear = factory.registeredBehaviorTrees();
+  EXPECT_TRUE(trees_after_clear.empty());
+}


### PR DESCRIPTION
Add functions to `BehaviorTreeFactory`, the base `Parser` class, and `XMLParsing` to clear the parser's internal list of registered behavior trees, plus supporting unit tests.

This is needed for cases where the factory is loading user-defined behavior trees during runtime, as opposed to just loading them once at startup, since if the  user deletes or edits the behavior tree definitions the factory needs to be able to reload them from scratch.

Based on work by @jliukkonen.