### PR TITLE
Fix PublisherZMQ segfault upon destruction

### DIFF
--- a/src/loggers/bt_zmq_publisher.cpp
+++ b/src/loggers/bt_zmq_publisher.cpp
@@ -92,6 +92,10 @@ PublisherZMQ::~PublisherZMQ()
   }
   flush();
   zmq_->context.shutdown();
+  if (send_future_.valid())
+  {
+    send_future_.wait();
+  }
   delete zmq_;
   ref_count = false;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(BT_TESTS
   gtest_subtree.cpp
   gtest_switch.cpp
   gtest_wakeup.cpp
+  gtest_logger_zmq.cpp
 )
 
 if( BT_COROUTINES )

--- a/tests/gtest_logger_zmq.cpp
+++ b/tests/gtest_logger_zmq.cpp
@@ -1,0 +1,51 @@
+#include <gtest/gtest.h>
+
+#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp_v3/loggers/bt_zmq_publisher.h"
+
+TEST(LoggerZMQ, ZMQLoggerDeletesCleanlyAfterTickingTree)
+{
+// GIVEN we create a behavior tree through the BT factory and attach a ZMQ publisher to it
+  static constexpr auto XML = R"(
+<root>
+    <BehaviorTree>
+    <SetBlackboard output_key="arg1" value="1" />
+    </BehaviorTree>
+</root>
+)";
+  BT::BehaviorTreeFactory factory;
+  auto tree = factory.createTreeFromText(XML);
+
+  {
+    BT::PublisherZMQ zmq_logger{tree, 1};
+    tree.tickRoot();
+    // WHEN zmq_logger goes out of scope
+  }
+
+  // THEN zmq_logger is destroyed cleanly without segfaulting
+  SUCCEED();
+}
+
+TEST(LoggerZMQ, ZMQLoggerDeletesCleanlyAfterNotTickingTree)
+{
+// GIVEN we create a behavior tree through the BT factory and attach a ZMQ publisher to it
+  static constexpr auto XML = R"(
+<root>
+    <BehaviorTree>
+    <SetBlackboard output_key="arg1" value="1" />
+    </BehaviorTree>
+</root>
+)";
+  BT::BehaviorTreeFactory factory;
+  auto tree = factory.createTreeFromText(XML);
+
+  {
+    BT::PublisherZMQ zmq_logger{tree, 1};
+    // GIVEN we haven't even ticked the tree, so ZMQ hasn't published any state change messages
+    // (meaning no send is pending and send_future_ has not been set)
+    // WHEN zmq_logger goes out of scope
+  }
+
+  // THEN zmq_logger is destroyed cleanly without segfaulting
+  SUCCEED();
+}


### PR DESCRIPTION
Wait for any in-progress message sending to finish before deleting ZMQ. This fixes some cases where a segfault could occur when an instance of PublisherZMQ was destroyed.

 I added unit tests based on the test case described in #426 (side note: that PR has a somewhat more complex solution to this same problem, but I pushed this one because I think the solution here is OK). I also added the bonus esoteric-yet-seen-in-the-wild case of deleting PublisherZMQ without even ticking the tree.

This is based on work by @JafarAbdi.