### PR TITLE
Fix missing closing brace in gtest_factory.cpp unit test

### DIFF
--- a/tests/gtest_factory.cpp
+++ b/tests/gtest_factory.cpp
@@ -496,6 +496,7 @@ const std::string xml_text_invalid = R"(
     // THEN no tree is registered
     auto trees = parser.registeredBehaviorTrees();
     EXPECT_TRUE(trees.empty());
+}
 
 TEST(BehaviorTreeFactory, ParserClearRegisteredBehaviorTrees)
 {


### PR DESCRIPTION
One of the test cases I added in #438 was missing a closing brace, which causes CI to fail when building, so this PR fixes that. Sorry for the mistake.