### PR TITLE
Ncurses dependency added to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Please note that **Ubuntu 18.04 is not supported anymore in version 4.X**. Ubunt
 
 First, install the following dependencies (optional, but recommended):
 
-     sudo apt-get install libzmq3-dev libboost-dev
+     sudo apt-get install libzmq3-dev libboost-dev libncurses5-dev libncursesw5-dev
      
 To compile and install the library, from the BehaviorTree.CPP folder, execute:
 


### PR DESCRIPTION
Hi,

First of all, I am a fresh user of the Behaviour Trees and it is so useful in Robotics with respect to FSMs. I appreciate for this awesome and open source repo.

While building the repo, CMake shows a warning as follows in Ubuntu 22.04.1 with 3.22.1 CMake version.

CMake Warning at CMakeLists.txt:187 (message):
  NCurses NOT found.  Skipping the build of manual selector node.

To avoid this warning Ncurses module should be installed. For this purpose I added libncurses5-dev and libncursesw5-dev modules to the deps part in the README.md.

Best regards.

Ali Aydin Kucukcollu