### PR TITLE
feature: add gitignore for clangd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 build*
 site/*
 /.vscode/
+
+# clangd cache
+/.cache/*


### PR DESCRIPTION
Clangd is really handy when coding with C/C++ that can be compiled with clang/llvm.

The problem is, it will create a `.cache` folder and put a bunch of files in it.

This commit just adds the `.cache` folder in gitignore.