### PR TITLE
remove unused boost dependencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,7 @@
   <depend condition="$ROS_VERSION == 2">rclcpp</depend>
   <depend condition="$ROS_VERSION == 2">ament_index_cpp</depend>
 
-  <depend>boost</depend>
+  <build_depend>libboost-dev</build_depend>
   <depend>libzmq3-dev</depend>
   <depend>libncurses-dev</depend>
 


### PR DESCRIPTION
The current package xml causes the bloomed debian package to pull in all of boost, which is pretty big.

Since coroutines are all that are needed, and since they are header-only, all that is needed is libboost-dev as a build dependency, not an absolute dependency.

Side effects: There are some platforms that have a rosdep key for `boost`, but not for `libboost-dev`. These are:
- alpine
- arch
- cygwin
- freebsd
- macports
- slackware

But given that compiling with boost is optional for this library, that doesn't seem like much of a sacrifice, and any affected users can PR to rosdep if desired.