### PR TITLE
Add the RunOnce decorator node

### DIFF
--- a/include/behaviortree_cpp/behavior_tree.h
+++ b/include/behaviortree_cpp/behavior_tree.h
@@ -37,12 +37,13 @@
 #include "behaviortree_cpp/actions/script_node.h"
 #include "behaviortree_cpp/actions/set_blackboard_node.h"
 
-#include "behaviortree_cpp/decorators/force_success_node.h"
+#include "behaviortree_cpp/decorators/delay_node.h"
 #include "behaviortree_cpp/decorators/force_failure_node.h"
+#include "behaviortree_cpp/decorators/force_success_node.h"
 #include "behaviortree_cpp/decorators/keep_running_until_failure_node.h"
+#include "behaviortree_cpp/decorators/run_once_node.h"
 #include "behaviortree_cpp/decorators/script_precondition.h"
 #include "behaviortree_cpp/decorators/timeout_node.h"
-#include "behaviortree_cpp/decorators/delay_node.h"
 
 #include <iostream>
 

--- a/include/behaviortree_cpp/decorators/run_once_node.h
+++ b/include/behaviortree_cpp/decorators/run_once_node.h
@@ -1,0 +1,54 @@
+/*  Copyright (C) 2018-2020 Davide Faconti, Eurecat -  All Rights Reserved
+*   Copyright (C) 2022 Gaël Écorchard, Czech Institute of Informatics, Robotics, and Cybernetics (ciirc) <gael.ecorchard@cvut.cz>
+*
+*   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+*   to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+*   and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+*   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+*
+*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+*   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include "behaviortree_cpp/decorator_node.h"
+
+namespace BT
+{
+/**
+ * @brief The RunOnceNode returns its child status but calls the child's tick() function only once.
+ *
+ * The pre- and postconditions are not checked again.
+ */
+class RunOnceNode : public DecoratorNode
+{
+public:
+  RunOnceNode(const std::string& name) : DecoratorNode(name, {})
+  {
+    setRegistrationID("RunOnce");
+  }
+
+private:
+  virtual BT::NodeStatus tick() override;
+  bool already_ticked_{false};
+};
+
+//------------ implementation ----------------------------
+
+inline NodeStatus RunOnceNode::tick()
+{
+  setStatus(NodeStatus::RUNNING);
+
+  if (already_ticked_)
+  {
+    return child_node_->status();
+  }
+  else
+  {
+    return child_node_->executeTick();
+  }
+  already_ticked_ = true;
+}
+}   // namespace BT

--- a/include/behaviortree_cpp/decorators/run_once_node.h
+++ b/include/behaviortree_cpp/decorators/run_once_node.h
@@ -47,8 +47,8 @@ inline NodeStatus RunOnceNode::tick()
   }
   else
   {
+    already_ticked_ = true;
     return child_node_->executeTick();
   }
-  already_ticked_ = true;
 }
 }   // namespace BT

--- a/src/bt_factory.cpp
+++ b/src/bt_factory.cpp
@@ -46,6 +46,7 @@ BehaviorTreeFactory::BehaviorTreeFactory()
   registerNodeType<RepeatNode>("Repeat");
   registerNodeType<TimeoutNode<>>("Timeout");
   registerNodeType<DelayNode>("Delay");
+  registerNodeType<RunOnceNode>("RunOnce");
 
   registerNodeType<ForceSuccessNode>("ForceSuccess");
   registerNodeType<ForceFailureNode>("ForceFailure");


### PR DESCRIPTION
This adds a RunOnce decorator node that will call its child' `executeTick()` only once. After the first time, it'll return the return value of child's `status()`.

Signed-off-by: Gaël Écorchard <gael.ecorchard@cvut.cz>