### PR TITLE
Define NodeConfiguration for BT3 compatibility

### DIFF
--- a/include/behaviortree_cpp/basic_types.h
+++ b/include/behaviortree_cpp/basic_types.h
@@ -203,11 +203,11 @@ using enable_if_not = typename std::enable_if<!Predicate::value>::type*;
 template <typename T>
 #ifdef USE_BTCPP3_OLD_NAMES
 using Optional = nonstd::expected<T, std::string>;
+// note: we use the name Optional instead of expected because it is more intuitive
+// for users that are not up to date with "modern" C++
 #else
 using Expected = nonstd::expected<T, std::string>;
 #endif
-// note: we use the name Optional instead of expected because it is more intuitive
-// for users that are not up to date with "modern" C++
 
 /** Usage: given a function/method like:
  *

--- a/include/behaviortree_cpp/tree_node.h
+++ b/include/behaviortree_cpp/tree_node.h
@@ -79,7 +79,7 @@ struct NodeConfig
 
 #ifdef USE_BTCPP3_OLD_NAMES
 // back compatibility
-using NodeConfig = NodeConfig;
+using NodeConfiguration = NodeConfig;
 #endif
 
 template <typename T>


### PR DESCRIPTION
Define `NodeConfiguration` for BT3 compatibility

I didn't compile because I don't need BT3 compatibility.