### PR TITLE
Fix some renaming for V4

### DIFF
--- a/include/behaviortree_cpp/action_node.h
+++ b/include/behaviortree_cpp/action_node.h
@@ -102,9 +102,9 @@ protected:
  *   the result of the method isHaltRequested() and stop your execution accordingly.
  *
  * - in the overriden halt() method, you can do some cleanup, but do not forget to
- *   invoke the base class method AsyncActionNode::halt();
+ *   invoke the base class method ThreadedAction::halt();
  *
- * - remember, with few exceptions, a halted AsyncAction must return NodeStatus::IDLE.
+ * - remember, with few exceptions, a halted ThreadedAction must return NodeStatus::IDLE.
  *
  * For a complete example, look at __AsyncActionTest__ in action_test_node.h in the folder test.
  *
@@ -137,12 +137,12 @@ private:
 };
 
 #ifdef USE_BTCPP3_OLD_NAMES
-using AsyncActionNode = ThreadedActionNode;
+using AsyncActionNode = ThreadedAction;
 #endif
 
 /**
- * @brief The StatefulAsyncAction is the preferred way to implement asynchronous Actions.
- * It is actually easier to use correctly, when compared with AsyncAction
+ * @brief The StatefulActionNode is the preferred way to implement asynchronous Actions.
+ * It is actually easier to use correctly, when compared with ThreadedAction
  *
  * It is particularly useful when your code contains a request-reply pattern,
  * i.e. when the actions sends an asynchronous request, then checks periodically

--- a/include/behaviortree_cpp/basic_types.h
+++ b/include/behaviortree_cpp/basic_types.h
@@ -201,12 +201,12 @@ using enable_if_not = typename std::enable_if<!Predicate::value>::type*;
  *
  * */
 template <typename T>
-#ifdef USE_BTCPP3_OLD_NAMES
-using Optional = nonstd::expected<T, std::string>;
-// note: we use the name Optional instead of expected because it is more intuitive
-// for users that are not up to date with "modern" C++
-#else
 using Expected = nonstd::expected<T, std::string>;
+#ifdef USE_BTCPP3_OLD_NAMES
+// note: we also use the name Optional instead of expected because it is more intuitive
+// for users that are not up to date with "modern" C++
+template <typename T>
+using Optional = nonstd::expected<T, std::string>;
 #endif
 
 /** Usage: given a function/method like:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,12 +28,6 @@ if( BTCPP_ENABLE_COROUTINES AND BT_COROUTINES_FOUND )
     LIST( APPEND BT_TESTS gtest_coroutines.cpp)
 endif()
 
-#if(ament_cmake_FOUND OR catkin_FOUND)
-#    # This test requires gmock. Since we don't have a uniform way to include
-#    # gmock for non-users, it is turned of when build without ros.
-#    list(APPEND BT_TESTS gtest_async_action_node.cpp)
-#endif()
-
 
 if(ament_cmake_FOUND AND BUILD_TESTING)
 
@@ -80,5 +74,15 @@ elseif(BTCPP_UNIT_TESTS)
     add_test(BehaviorTreeCoreTest ${BEHAVIOR_TREE_LIBRARY}_test)
 
 endif()
+
+# if(BUILD_TESTING AND (ament_cmake_FOUND OR catkin_FOUND))
+#    # This test requires gmock. Since we don't have a uniform way to include
+#    # gmock for non-users, it is turned of when build without ros.
+#    list(APPEND BT_TESTS gtest_async_action_node.cpp)
+#    target_link_libraries(${BEHAVIOR_TREE_LIBRARY}_test
+#         ${BEHAVIOR_TREE_LIBRARY}
+#         gmock
+#     )
+# endif()
 
 target_compile_definitions(${BEHAVIOR_TREE_LIBRARY}_test PRIVATE BT_TEST_FOLDER="${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION
This time I took the time to use `-DUSE_V3_COMPATIBLE_NAMES=ON'.