### PR TITLE
Fixed use of ros_pkg for ROS1 applications

### DIFF
--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -173,12 +173,12 @@ void XMLParser::Pimpl::loadDocImpl(tinyxml2::XMLDocument* doc, bool add_includes
 #elif defined USING_ROS2
         ros_pkg_path =
             ament_index_cpp::get_package_share_directory(ros_pkg_relative_path);
-        file_path = std::filesystem::path(ros_pkg_path) / file_path;
 #else
         throw RuntimeError("Using attribute [ros_pkg] in <include>, but this library was "
                            "compiled without ROS support. Recompile the BehaviorTree.CPP "
                            "using catkin");
 #endif
+        file_path = std::filesystem::path(ros_pkg_path) / file_path;
       }
     }
 


### PR DESCRIPTION
The include tag wasn't working properly for ROS1 applications when used with the ros_pkg argument. For instance, a BT that had this line: 
``` 
<include ros_pkg="bt_tools_craftsman" path="behaviors/add_affordance_template.xml" />
```
would crash, with the error of XML_FILE_NOT_FOUND. This fix solves the issue.