### PR TITLE
fixing missed return type related to issue 489

### DIFF
--- a/include/behaviortree_cpp/basic_types.h
+++ b/include/behaviortree_cpp/basic_types.h
@@ -73,6 +73,7 @@ template <typename T>
 inline T convertFromString(StringView /*str*/)
 {
   static_assert(true, "This template specialization of convertFromString doesn't exist");
+  return T();
 }
 
 template <>
@@ -371,7 +372,7 @@ inline PortsList getProvidedPorts(enable_if<has_static_method_providedPorts<T>> 
 
 template <typename T>
 inline PortsList
-    getProvidedPorts(enable_if_not<has_static_method_providedPorts<T>> = nullptr)
+getProvidedPorts(enable_if_not<has_static_method_providedPorts<T>> = nullptr)
 {
   return {};
 }


### PR DESCRIPTION
fixing missed return type error occurred during build after commit 5e16d72c18a4990a73e2a3cdef9150805e4a66ea related to [issue 489](https://github.com/BehaviorTree/BehaviorTree.CPP/issues/489#issue-1516359545)