### PR TITLE
Fix libboost-coroutine-dev dependency in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,7 @@
   <depend condition="$ROS_VERSION == 2">rclcpp</depend>
   <depend condition="$ROS_VERSION == 2">ament_index_cpp</depend>
 
-  <build_depend>libboost-dev</build_depend>
+  <build_depend>libboost-coroutine-dev</build_depend>
   <depend>libzmq3-dev</depend>
   <depend>libncurses-dev</depend>
 


### PR DESCRIPTION
Dependency was updated in the `README.md` in an earlier [commit](https://github.com/BehaviorTree/BehaviorTree.CPP/commit/1dc1c2e520ac42fec449d86b06a4b47777ca2687) but not in `package.xml`.

Related to issue #444.