### PR TITLE
Add ROS2 CMakeLists.txt example

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,21 @@ add_executable(${PROJECT_NAME} "hello_BT.cpp")
 target_link_libraries(${PROJECT_NAME} BT::behaviortree_cpp)
 ```
 
+**Using BT.CPP in ROS2**
+
+If you want to use BT.CPP in your ROS2 application, a typical **CMakeLists.txt** file
+might look like this:
+
+```cmake
+...
+find_package(behaviortree_cpp REQUIRED)
+find_package(Threads REQUIRED)
+
+add_executable(${PROJECT_NAME} "hello_BT.cpp")
+target_link_libraries(${PROJECT_NAME} BT::behaviortree_cpp Threads::Threads)
+...
+```
+
 # License
 
 The MIT License (MIT)


### PR DESCRIPTION
Hi, I managed to compile the BehaviorTree.CPP with `colcon build` & added the library into a ROS2 package. However, when building the package, it throws a `Threads::Threads` not found error after adding the library into the package CMakeLists.txt (with CMake version 3.10.2).
```cmake
CMake Error at CMakeLists.txt:40 (add_executable):
  Target "waypoint_bt_node" links to target "Threads::Threads" but the
  target was not found.  Perhaps a find_package() call is missing for an
  IMPORTED target, or an ALIAS target is missing?
```
To resolve this issue, finding the Thread package & linking it to the executable resolves the issue.
```cmake
...
find_package(behaviortree_cpp REQUIRED)
find_package(Threads REQUIRED)

add_executable(${PROJECT_NAME} "src/waypoint_bt_node.cpp")
target_link_libraries(${PROJECT_NAME} BT::behaviortree_cpp Threads::Threads)
...
```
With that in mind, a ROS2 section on the CMakeLists configurtion was added to `README.md`.
