### PR TITLE
using tinyxml ErrorStr() instead of ErrorName() to get more info about missing xml file

### DIFF
--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -133,7 +133,7 @@ void XMLParser::Pimpl::loadDocImpl(tinyxml2::XMLDocument* doc, bool add_includes
   if (doc->Error())
   {
     char buffer[200];
-    sprintf(buffer, "Error parsing the XML: %s", doc->ErrorName());
+    sprintf(buffer, "Error parsing the XML: %s", doc->ErrorStr());
     throw RuntimeError(buffer);
   }
 


### PR DESCRIPTION
During the loading process of BT from an XML file that includes other xml files, inclusion of a not existing file (or misspelled name/path) leads to the following error on the console:
```
Error parsing the XML: XML_ERROR_FILE_NOT_FOUND
```
but this give no info about which file is missing .
using doc->ErrorStr() instead of doc->ErrorName() will result in :
```
Error parsing the XML: Error=XML_ERROR_FILE_NOT_FOUND ErrorID=3 (0x3) Line number=0: filename=/[path_to_file]/[filename].xml
```
  