### PR TITLE
fix alloc-dealloc-mismatch for _storage.str.data

### DIFF
--- a/include/behaviortree_cpp/utils/simple_string.hpp
+++ b/include/behaviortree_cpp/utils/simple_string.hpp
@@ -53,7 +53,7 @@ class SimpleString {
   ~SimpleString()
   {
     if (!isSOO()) {
-      delete _storage.str.data;
+      delete[] _storage.str.data;
     }
     _storage.soo.capacity_left = CAPACITY;
   }


### PR DESCRIPTION
The variable `_storage.str.data` is a `char*` allocated as

```
_storage.str.data = new char[size + 1];
```

This means that we should use `delete[]` to deallocate it, to avoid undefined behavior.