### PR TITLE
 ReactiveSequence _skipIf issue fix

### DIFF
--- a/src/controls/reactive_sequence.cpp
+++ b/src/controls/reactive_sequence.cpp
@@ -60,7 +60,7 @@ NodeStatus ReactiveSequence::tick()
     }   // end switch
   }     //end for
 
-  if (success_count == childrenCount())
+  //if (success_count == childrenCount())
   {
     resetChildren();
   }

--- a/tests/gtest_skipping.cpp
+++ b/tests/gtest_skipping.cpp
@@ -3,6 +3,7 @@
 #include "behaviortree_cpp/basic_types.h"
 #include "behaviortree_cpp/bt_factory.h"
 #include "test_helper.hpp"
+#include "../sample_nodes/dummy_nodes.h"
 
 using namespace BT;
 
@@ -113,4 +114,120 @@ TEST(SkippingLogic, ReactiveSingleChild)
   auto tree = factory.createTreeFromText(xml_text, root_blackboard);
 
   tree.tickWhileRunning();
+}
+
+enum DeviceType { BATT=1, CONTROLLER=2 };
+BT::NodeStatus checkLevel2(BT::TreeNode &self)
+{
+  double percent = self.getInput<double>("percentage").value();
+  DeviceType devType;
+  auto res = self.getInput("deviceType", devType);
+  if(!res) {
+    throw std::runtime_error(res.error());
+  }
+
+  if(devType == DeviceType::BATT)
+  {
+    self.setOutput("isLowBattery", (percent < 25));
+  }
+  std::cout << "Device: " << devType << " Level: " << percent << std::endl;
+  return BT::NodeStatus::SUCCESS;
+}
+
+TEST(SkippingLogic, RepeatedSkippingReactiveSequence)
+{
+  BehaviorTreeFactory factory;
+  std::array<int, 2> counters;
+  RegisterTestTick(factory, "Test", counters);
+
+  //! setting the battery level = 50
+  const std::string xml_text = R"(
+
+    <root BTCPP_format="4" >
+       <BehaviorTree ID="PowerManagerT">
+          <ReactiveSequence>
+             <Script code=" LOW_BATT:=50 "/>
+             <CheckLevel deviceType="BATT"
+                         percentage="{LOW_BATT}"
+                         isLowBattery="{isLowBattery}"/>
+             <TestA _skipIf="!isLowBattery"/>
+             <TestB/>
+         </ReactiveSequence>
+       </BehaviorTree>
+    </root>)";
+
+  factory.registerNodeType<DummyNodes::SaySomething>("SaySomething");
+  factory.registerSimpleCondition("CheckLevel", std::bind(checkLevel2, std::placeholders::_1),
+                                  { BT::InputPort("percentage"),
+                                   BT::InputPort("deviceType"),
+                                   BT::OutputPort("isLowBattery")});
+  factory.registerScriptingEnums<DeviceType>();
+
+  auto tree = factory.createTreeFromText(xml_text);
+
+  BT::NodeStatus status;
+  try {
+    int runs = 0;
+    while(runs < 5)
+    {
+      status = tree.tickOnce();
+      tree.sleep(std::chrono::milliseconds(10));
+      runs++;
+    }
+  } catch (BT::LogicError err) {
+    std::cout << err.what() << std::endl;
+  }
+
+  ASSERT_EQ(status, NodeStatus::SUCCESS);
+  ASSERT_EQ(counters[0], 0);
+  ASSERT_EQ(counters[1], 5);
+}
+
+TEST(SkippingLogic, RepeatedNoSkippingReactiveSequence)
+{
+  BehaviorTreeFactory factory;
+  std::array<int, 2> counters;
+  RegisterTestTick(factory, "Test", counters);
+
+  //! setting the battery level = 10
+  const std::string xml_text = R"(
+
+    <root BTCPP_format="4" >
+       <BehaviorTree ID="PowerManagerT">
+          <ReactiveSequence>
+             <Script code=" LOW_BATT:=10 "/>
+             <CheckLevel deviceType="BATT"
+                         percentage="{LOW_BATT}"
+                         isLowBattery="{isLowBattery}"/>
+             <TestA _skipIf="!isLowBattery"/>
+             <TestB/>
+         </ReactiveSequence>
+       </BehaviorTree>
+    </root>)";
+
+  factory.registerNodeType<DummyNodes::SaySomething>("SaySomething");
+  factory.registerSimpleCondition("CheckLevel", std::bind(checkLevel2, std::placeholders::_1),
+                                  { BT::InputPort("percentage"),
+                                   BT::InputPort("deviceType"),
+                                   BT::OutputPort("isLowBattery")});
+  factory.registerScriptingEnums<DeviceType>();
+
+  auto tree = factory.createTreeFromText(xml_text);
+
+  BT::NodeStatus status;
+  try {
+    int runs = 0;
+    while(runs < 5)
+    {
+      status = tree.tickOnce();
+      tree.sleep(std::chrono::milliseconds(10));
+      runs++;
+    }
+  } catch (BT::LogicError err) {
+    std::cout << err.what() << std::endl;
+  }
+
+  ASSERT_EQ(status, NodeStatus::SUCCESS);
+  ASSERT_EQ(counters[0], 5);
+  ASSERT_EQ(counters[1], 5);
 }

--- a/tests/script_parser_test.cpp
+++ b/tests/script_parser_test.cpp
@@ -5,6 +5,7 @@
 #include "../sample_nodes/dummy_nodes.h"
 
 #include <lexy/input/string_input.hpp>
+#include "test_helper.hpp"
 
 TEST(ParserTest, AnyTypes)
 {


### PR DESCRIPTION
Hi Davide, 

I fixed the _skipIf issue described in [this issue](https://github.com/BehaviorTree/BehaviorTree.CPP/issues/525#issue-1623185459) and created two tests: **SkippingLogic.RepeatedSkippingReactiveSequence** and **SkippingLogic.RepeatedNoSkippingReactiveSequence** to verify.

**PS**: The issue is only observable when ticking the tree continuously. E.g Calling tickOnce() inside a while loop. I hope this helps.