### PR TITLE
fix tests with colcon not being run

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,7 +37,7 @@ if(ament_cmake_FOUND AND BUILD_TESTING)
 
     find_package(ament_cmake_gtest REQUIRED)
 
-    ament_add_gtest_executable(${BTCPP_LIBRARY}_test ${BT_TESTS})
+    ament_add_gtest(${BTCPP_LIBRARY}_test ${BT_TESTS})
     target_link_libraries(${BTCPP_LIBRARY}_test
         ${TEST_DEPENDECIES}
         ${ament_LIBRARIES})


### PR DESCRIPTION
I ran into a problem when trying to run `colcon test --packages-select behaviortree_cpp` where the tests wouldn't actually be executed.

Turns out `ament_add_gtest_executable` doesn't go so far as to register the executable as tests preventing colcon from seeing them. `ament_add_gtest` does and the tests now run successfully. 

Read about it here:
[Relevant question on ros answers ](https://answers.ros.org/question/399412/colcon-test-not-running-gtests/)