### PR TITLE
Fix writeTreeNodesModelXML

### DIFF
--- a/include/behaviortree_cpp/tree_node.h
+++ b/include/behaviortree_cpp/tree_node.h
@@ -450,10 +450,12 @@ inline void assignDefaultRemapping(NodeConfig& config)
     const auto direction = it.second.direction();
     if (direction != PortDirection::OUTPUT)
     {
+      // PortDirection::{INPUT,INOUT}
       config.input_ports[port_name] = "=";
     }
     if (direction != PortDirection::INPUT)
     {
+      // PortDirection::{OUTPUT,INOUT}
       config.output_ports[port_name] = "=";
     }
   }

--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -886,7 +886,7 @@ void addNodeModelToXML(const TreeNodeManifest& model,
     {
       port_element->SetAttribute("type", BT::demangle(port_info.type()).c_str());
     }
-    if (!port_info.defaultValue())
+    if (port_info.defaultValue().has_value())
     {
       port_element->SetAttribute("default", port_info.defaultValue()->c_str());
     }


### PR DESCRIPTION
In  `addNodeModelToXML`, the condition whether to add an attribute for the default value or not was inverted and corrupted the generated xml code.

Also adds a small comment.