### PR TITLE
SimpleThreadedActionNode that wraps given functor in ThreadedAction for execution in a separate thread

### DIFF
--- a/include/behaviortree_cpp/action_node.h
+++ b/include/behaviortree_cpp/action_node.h
@@ -141,6 +141,40 @@ using AsyncActionNode = ThreadedAction;
 #endif
 
 /**
+ * @brief The SimpleThreadedActionNode provides an easy to use ThreadedActionNode.
+ * The user should simply provide a callback with this signature
+ *
+ *    BT::NodeStatus functionName(ThreadedAction&)
+ *
+ * This avoids the hassle of inheriting from a ThreadedAction.
+ *
+ * Using lambdas or std::bind it is easy to pass a pointer to a method.
+ * 
+ * SimpleThreadedActionNode is executed asynchronously in a new thread, the node
+ * returns BT::NodeStatus::RUNNING while the thread is doing its work.
+ * If you want halting support, you must periodically check the result of the method
+ * isHaltRequested() and stop execution when it returns true.
+ * 
+ * NodeParameters aren't supported.
+ */
+class SimpleThreadedActionNode : public ThreadedAction
+{
+public:
+  typedef std::function<NodeStatus(ThreadedAction&)> ThreadedActionFunctor;
+
+  // You must provide the function to call in a new thread when onStart() is invoked
+  SimpleThreadedActionNode(const std::string& name, ThreadedActionFunctor threaded_action_functor,
+                   const NodeConfig& config);
+
+  ~SimpleThreadedActionNode() override = default;
+
+protected:
+  virtual NodeStatus tick() override final;
+
+  ThreadedActionFunctor threaded_action_functor_;
+};
+
+/**
  * @brief The StatefulActionNode is the preferred way to implement asynchronous Actions.
  * It is actually easier to use correctly, when compared with ThreadedAction
  *

--- a/include/behaviortree_cpp/bt_factory.h
+++ b/include/behaviortree_cpp/bt_factory.h
@@ -234,6 +234,19 @@ public:
                             const SimpleActionNode::TickFunctor& tick_functor,
                             PortsList ports = {});
   /**
+    * @brief registerSimpleThreadedAction help you register nodes of type SimpleThreadedActionNode,
+    *        which will execute provided callback in a new thread, and return BT::NodeStatus::RUNNING
+    *        until the callback returns.
+    *
+    * @param ID            registration ID
+    * @param tick_functor  the callback to be invoked in a new thread.
+    * @param ports         if your SimpleNode requires ports, provide the list here.
+    *
+    * */
+  void registerSimpleThreadedAction(const std::string& ID,
+                            const SimpleThreadedActionNode::ThreadedActionFunctor& threaded_action_functor,
+                            PortsList ports = {});
+  /**
     * @brief registerSimpleCondition help you register nodes of type SimpleConditionNode.
     *
     * @param ID            registration ID

--- a/src/action_node.cpp
+++ b/src/action_node.cpp
@@ -47,6 +47,24 @@ NodeStatus SimpleActionNode::tick()
   return status;
 }
 
+SimpleThreadedActionNode::SimpleThreadedActionNode(const std::string& name,
+                                   SimpleThreadedActionNode::ThreadedActionFunctor threaded_action_functor,
+                                   const NodeConfig& config) :
+  ThreadedAction(name, config), threaded_action_functor_(std::move(threaded_action_functor))
+{}
+
+NodeStatus SimpleThreadedActionNode::tick()
+{
+  NodeStatus prev_status = status();
+
+  NodeStatus status = threaded_action_functor_(*this);
+  if (status != prev_status)
+  {
+    setStatus(status);
+  }
+  return status;
+}
+
 //-------------------------------------------------------
 
 SyncActionNode::SyncActionNode(const std::string& name, const NodeConfig& config) :

--- a/src/bt_factory.cpp
+++ b/src/bt_factory.cpp
@@ -131,6 +131,19 @@ void BehaviorTreeFactory::registerSimpleAction(
   registerBuilder(manifest, builder);
 }
 
+void BehaviorTreeFactory::registerSimpleThreadedAction(
+    const std::string& ID, const SimpleThreadedActionNode::ThreadedActionFunctor& threaded_action_functor,
+    PortsList ports)
+{
+  NodeBuilder builder = [threaded_action_functor, ID](const std::string& name,
+                                           const NodeConfig& config) {
+    return std::make_unique<SimpleThreadedActionNode>(name, threaded_action_functor, config);
+  };
+
+  TreeNodeManifest manifest = {NodeType::ACTION, ID, std::move(ports), {}};
+  registerBuilder(manifest, builder);
+}
+
 void BehaviorTreeFactory::registerSimpleDecorator(
     const std::string& ID, const SimpleDecoratorNode::TickFunctor& tick_functor,
     PortsList ports)


### PR DESCRIPTION
Also provides `registerSimpleThreadedAction` method similar to `registerSimpleAction` to quickly register lambdas executing in a separate thread for use in behavior trees.

When implementing this I noticed that `ThreadedAction` name does not conform to the naming convention of other classes in the same "functionality group" ... should I change it to `ThreadedActionNode` and perhaps also update it in the documentation?