### PR TITLE
Fix Blackboard::set() for StringView

### DIFF
--- a/include/behaviortree_cpp/blackboard.h
+++ b/include/behaviortree_cpp/blackboard.h
@@ -198,6 +198,7 @@ public:
       Any new_value(value);
 
       // special case: entry exists but it is not strongly typed... yet
+      // std::string_view entries are the only entries that are strongly-typed from the beginning.
       if (!port_info.isStronglyTyped())
       {
         // Use the new type to create a new entry that is strongly typed.
@@ -214,10 +215,10 @@ public:
           previous_type != new_value.type())
       {
         bool mismatching = true;
-        if (std::is_constructible<StringView, T>::value)
+        if constexpr (std::is_constructible<StringView, T>::value)
         {
-          Any any_from_string = port_info.parseString(value);
-          if (any_from_string.empty() == false)
+          Any any_from_string = Any(std::string(value));
+          if (!any_from_string.empty())
           {
             mismatching = false;
             new_value = std::move(any_from_string);

--- a/tests/gtest_blackboard.cpp
+++ b/tests/gtest_blackboard.cpp
@@ -350,3 +350,13 @@ TEST(BlackboardTest, AnyPtrLocked)
     ASSERT_NE(cycles, value);
   }
 }
+
+TEST(BlackboardTest, SetStringView)
+{
+  auto bb = Blackboard::create();
+
+  constexpr BT::StringView string_view_const = "BehaviorTreeCpp";
+  bb->set("string_view", string_view_const);
+
+  ASSERT_NO_THROW(bb->set("string_view", string_view_const));
+}


### PR DESCRIPTION
The second call to `Blackboard::set()` with the same key was not working for `StringView` because `port_info.parseString(value)` returns an empty `Any`.
`Any(std::string(value))` is used instead for `StringView` when the key already exists.