### PR TITLE
Fix missing attribute in generated XML (writeTreeNodesModelXML)

### DIFF
--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -1008,7 +1008,7 @@ std::string writeTreeNodesModelXML(const BehaviorTreeFactory& factory,
 {
   XMLDocument doc;
 
-  XMLElement* rootXML = doc.NewElement("root");
+  XMLElement* rootXML = doc.NewElement("root BTCPP_format=\"4\"");
   doc.InsertFirstChild(rootXML);
 
   XMLElement* model_root = doc.NewElement("TreeNodesModel");


### PR DESCRIPTION
Fix missing attribute [BTCPP_format="4"] in the XML generated by the writeTreeNodesModelXML function. This eliminates Groot 2 complaints when importing XML models.