### PR TITLE
Proper fix for missing attribute

### DIFF
--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -1008,7 +1008,8 @@ std::string writeTreeNodesModelXML(const BehaviorTreeFactory& factory,
 {
   XMLDocument doc;
 
-  XMLElement* rootXML = doc.NewElement("root BTCPP_format=\"4\"");
+  XMLElement* rootXML = doc.NewElement("root");
+  rootXML->SetAttribute("BTCPP_format", "4");
   doc.InsertFirstChild(rootXML);
 
   XMLElement* model_root = doc.NewElement("TreeNodesModel");


### PR DESCRIPTION
@facontidavide I did a mistake in my previous fix which you merged. While it worked, it also added `BTCPP_format` to the closing tag, which is obviously wrong.
In this new commit I'm setting it properly with `SetAttribute` function. Sorry, I didn't notice at first.