### PR TITLE
changing resetStatus to public

### DIFF
--- a/include/behaviortree_cpp_v3/tree_node.h
+++ b/include/behaviortree_cpp_v3/tree_node.h
@@ -182,6 +182,9 @@ public:
   // Notify the tree should be ticked again()
   void emitStateChanged();
 
+  /// Equivalent to setStatus(NodeStatus::IDLE)
+  void resetStatus();
+
 protected:
   /// Method to be implemented by the user
   virtual BT::NodeStatus tick() = 0;
@@ -222,9 +225,6 @@ private:
   PostTickOverrideCallback post_condition_callback_;
 
   std::shared_ptr<WakeUpSignal> wake_up_;
-
-  /// Equivalent to setStatus(NodeStatus::IDLE)
-  void resetStatus();
 };
 
 //-------------------------------------------------------


### PR DESCRIPTION
Needed for unit test coverage to reset the root nodes. I can appreciate that this is to prevent users from doing unwise things, but I think at least a reset option is a necessary public method even if `setStatus` is not. 