### PR TITLE
Fix error when building static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,6 @@ else()
     add_definitions(-Wpedantic)
 endif()
 
-#set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
 #---- project configuration ----
 option(BTCPP_SHARED_LIBS "Build shared libraries" ON)
 option(BTCPP_BUILD_TOOLS "Build commandline tools" ON)
@@ -154,6 +152,7 @@ if (BTCPP_SHARED_LIBS)
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
     add_library(${BTCPP_LIBRARY} SHARED ${BT_SOURCE})
 else()
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
     add_library(${BTCPP_LIBRARY} STATIC ${BT_SOURCE})
 endif()
 

--- a/include/behaviortree_cpp/scripting/operators.hpp
+++ b/include/behaviortree_cpp/scripting/operators.hpp
@@ -38,7 +38,7 @@ struct ExprBase
   virtual Any evaluate(Environment& env) const = 0;
 };
 
-std::string ErrorNotInit(const char* side, const char* op_str)
+inline std::string ErrorNotInit(const char* side, const char* op_str)
 {
   return StrCat("The ", side, " operand of the operator [", op_str,
                 "] is not initialized");


### PR DESCRIPTION
This commit fixes errors when building the library with option `-DBTCPP_SHARED_LIBS=OFF`