### PR TITLE
Refactoring WhileDoElseNode to allow 2 or 3 children

### DIFF
--- a/src/controls/while_do_else_node.cpp
+++ b/src/controls/while_do_else_node.cpp
@@ -29,9 +29,9 @@ NodeStatus WhileDoElseNode::tick()
 {
   const size_t children_count = children_nodes_.size();
 
-  if (children_count != 3)
+  if (children_count != 2 && children_count != 3)
   {
-    throw std::logic_error("WhileDoElse must have 3 children");
+    throw std::logic_error("WhileDoElseNode must have either 2 or 3 children");
   }
 
   setStatus(NodeStatus::RUNNING);
@@ -47,13 +47,23 @@ NodeStatus WhileDoElseNode::tick()
 
   if (condition_status == NodeStatus::SUCCESS)
   {
-    haltChild(2);
+    if (children_count == 3)
+    {
+      haltChild(2);
+    }
     status = children_nodes_[1]->executeTick();
   }
   else if (condition_status == NodeStatus::FAILURE)
   {
-    haltChild(1);
-    status = children_nodes_[2]->executeTick();
+    if (children_count == 3)
+    {
+      haltChild(1);
+      status = children_nodes_[2]->executeTick();
+    }
+    else if (children_count == 2)
+    {
+      status = NodeStatus::FAILURE;
+    }
   }
 
   if (status == NodeStatus::RUNNING)


### PR DESCRIPTION
**Description:**

This PR addresses the constraint in the WhileDoElse node that mandates the presence of three child nodes. The aim is to improve flexibility and align its behavior with that of the IfThenElse node which allows either two or three child nodes.

**Testing:**

Tests have been conducted to verify the behavior with both two and three child nodes.

Looking forward to your feedback, thank you!