### PR TITLE
fix: Update Windows github workflow to run the tests #646

### DIFF
--- a/.github/workflows/cmake_windows.yml
+++ b/.github/workflows/cmake_windows.yml
@@ -50,5 +50,5 @@ jobs:
       
     - name: run test (Windows)
       working-directory: ${{github.workspace}}/build
-      run: ctest -C $BUILD_TYPE
+      run: $env:PATH+=";${{env.BUILD_TYPE}}"; tests/${{env.BUILD_TYPE}}/behaviortree_cpp_test.exe
       


### PR DESCRIPTION
Update the action so the tests actually run. Calls the executable directly in a similar way to ubuntu action. 

Currently 1 test is failing.