### PR TITLE
feat: improve runtime error output for missing manifest in xml_parser

### DIFF
--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -600,7 +600,9 @@ TreeNode::Ptr XMLParser::PImpl::createNodeFromXML(const XMLElement* element,
   {
     if(!manifest)
     {
-      throw RuntimeError("Missing manifest. It shouldn't happen. Please report this issue");
+      std::stringstream ss; 
+      ss << "Missing manifest for element_ID: " << element_ID << ". It shouldn't happen. Please report this issue.";
+      throw RuntimeError(ss.str());
     }
 
     //Check that name in remapping can be found in the manifest

--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -600,9 +600,8 @@ TreeNode::Ptr XMLParser::PImpl::createNodeFromXML(const XMLElement* element,
   {
     if(!manifest)
     {
-      std::stringstream ss; 
-      ss << "Missing manifest for element_ID: " << element_ID << ". It shouldn't happen. Please report this issue.";
-      throw RuntimeError(ss.str());
+      auto msg = StrCat("Missing manifest for element_ID: ", element_ID, ". It shouldn't happen. Please report this issue.");
+      throw RuntimeError(msg);
     }
 
     //Check that name in remapping can be found in the manifest


### PR DESCRIPTION
By adding the element ID for which the parser failed to the output it is easier to understand possible XML parsing failures.