### PR TITLE
Use feature test macro to check availability of `std::from_chars`

### DIFF
--- a/include/behaviortree_cpp/utils/safe_any.hpp
+++ b/include/behaviortree_cpp/utils/safe_any.hpp
@@ -348,7 +348,7 @@ nonstd::expected<T, std::string> Any::stringToNumber() const
   static_assert(std::is_arithmetic_v<T> && !std::is_same_v<T, bool>, "Expecting a numeric type");
 
   const auto str = linb::any_cast<SafeAny::SimpleString>(_any);
-#if __has_include(<GL/gl.h>)
+#if __cpp_lib_to_chars >= 201611L
   T out;
   auto [ptr, err] = std::from_chars(str.data(), str.data() + str.size(), out);
   if(err == std::errc())


### PR DESCRIPTION
Testing for proper availability of `std::from_chars` is best done by testing

    #if __cpp_lib_to_chars >= 201611L

according to https://en.cppreference.com/w/cpp/utility/from_chars.
I don't know what the motivation of checking `__has_include(<GL/gl.h>)` was.

Without this test, using `from_chars` fails to build on older gcc and clang versions:
https://godbolt.org/z/18nPWehaq