### PR TITLE
erase server_port+1

### DIFF
--- a/src/loggers/groot2_publisher.cpp
+++ b/src/loggers/groot2_publisher.cpp
@@ -115,7 +115,7 @@ Groot2Publisher::Groot2Publisher(const BT::Tree& tree,
   {
     std::unique_lock<std::mutex> lk(Groot2Publisher::used_ports_mutex);
     if(Groot2Publisher::used_ports.count(server_port) != 0 ||
-        Groot2Publisher::used_ports.count(server_port+1 != 0))
+        Groot2Publisher::used_ports.count(server_port+1) != 0)
     {
       auto msg = StrCat("Another instance of Groot2Publisher is using port ",
                         std::to_string(server_port));
@@ -196,6 +196,7 @@ Groot2Publisher::~Groot2Publisher()
   {
     std::unique_lock<std::mutex> lk(Groot2Publisher::used_ports_mutex);
     Groot2Publisher::used_ports.erase(_p->server_port);
+    Groot2Publisher::used_ports.erase(_p->server_port+1);
   }
 }
 


### PR DESCRIPTION
Erase the `server_port+1` in `Groot2Publisher::used_ports` to properly destruct `class Groot2Publisher`