### PR TITLE
fix: ensure public get config overload is used

### DIFF
--- a/.github/workflows/pixi.yaml
+++ b/.github/workflows/pixi.yaml
@@ -13,27 +13,21 @@ jobs:
       matrix:
         include:
         - os: windows-latest
-          shell: "pwsh -Login {0}"
-          pixi_install: "iwr -useb https://pixi.sh/install.ps1 | iex"
           build_depend: vs2022_win-64=19.*
           tests_command: "'PATH=\\\"$PATH;build/Release\\\" build/tests/Release/behaviortree_cpp_test.exe'"
         - os: ubuntu-latest
-          shell: "bash -el {0}"
-          pixi_install: "curl -fsSL https://pixi.sh/install.sh | bash"
           build_depend: "gxx=12.2.*"
           tests_command: "./build/tests/behaviortree_cpp_test"
     runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: ${{ matrix.shell }}
     steps:
       # Pixi is the tool used to create/manage conda environment
-      - name: Set up pixi
-        run: |
-          ${{ matrix.pixi_install }}
-      - name: Setup windows path
-        if: "startsWith(runner.os, 'windows')"
-        run: echo "C:\Users\runneradmin\AppData\Local\pixi\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - uses: prefix-dev/setup-pixi@v0.4.1
+        with:
+          pixi-version: v0.7.0
+          locked: false
+          frozen: false
+          run-install: false
+          manifest-path: build-env/pixi.yaml
       - name: Make pixi workspace
         run: |
           pixi init build-env

--- a/include/behaviortree_cpp/flatbuffers/bt_flatbuffer_helper.h
+++ b/include/behaviortree_cpp/flatbuffers/bt_flatbuffer_helper.h
@@ -80,13 +80,15 @@ inline void CreateFlatbuffersBehaviorTree(flatbuffers::FlatBufferBuilder& builde
       children_uid.push_back(child->UID());
     }
 
+    // Const cast to ensure public access to config() overload
+    const auto& node_config = const_cast<BT::TreeNode const &>(*node).config();
     std::vector<flatbuffers::Offset<Serialization::PortConfig>> ports;
-    for (const auto& it : node->config().input_ports)
+    for (const auto& it : node_config.input_ports)
     {
       ports.push_back(Serialization::CreatePortConfigDirect(builder, it.first.c_str(),
                                                             it.second.c_str()));
     }
-    for (const auto& it : node->config().output_ports)
+    for (const auto& it : node_config.output_ports)
     {
       ports.push_back(Serialization::CreatePortConfigDirect(builder, it.first.c_str(),
                                                             it.second.c_str()));


### PR DESCRIPTION
(At least with MSVC compiler) protected `config` member is called instead of `const` public `config` member. Const cast ensures public const member is used

And fix pixi pipeline by using the now available github action.