### PR TITLE
Retry after tick 

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(BT_TESTS
   gtest_subtree.cpp
   gtest_switch.cpp
   gtest_wakeup.cpp
+  gtest_retry.cpp
 )
 
 if( ZMQ_FOUND )

--- a/tests/gtest_decorator.cpp
+++ b/tests/gtest_decorator.cpp
@@ -115,7 +115,14 @@ TEST_F(RetryTest, RetryTestA)
 {
   action.setExpectedResult(NodeStatus::FAILURE);
 
-  root.executeTick();
+  while (true)
+  {
+    root.executeTick();
+    if (root.status() != NodeStatus::RUNNING)
+    {
+      break;
+    }
+  }
   ASSERT_EQ(NodeStatus::FAILURE, root.status());
   ASSERT_EQ(3, action.tickCount());
 

--- a/tests/gtest_retry.cpp
+++ b/tests/gtest_retry.cpp
@@ -1,0 +1,57 @@
+#include <gtest/gtest.h>
+#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp_v3/decorators/retry_node.h"
+
+using BT::NodeStatus;
+
+class FlipN : public BT::SyncActionNode
+{
+public:
+  FlipN(const std::string& name, int N, const NodeStatus initial_return_value):
+    BT::SyncActionNode(name, {}), counter_(N), initial_return_value_(initial_return_value)
+  {
+  }
+
+  NodeStatus tick() override
+  {
+    // flip returned value after calling tick() N times
+    const NodeStatus return_val = counter_-- > 0 ? initial_return_value_ : (initial_return_value_ == NodeStatus::SUCCESS ? NodeStatus::FAILURE : NodeStatus::SUCCESS);
+    const std::string msg = return_val == NodeStatus::SUCCESS ? "SUCCESS" : "FAILURE";
+    std::cout << name() << "; " << msg << std::endl;
+    return return_val;
+  }
+
+  private:
+    NodeStatus initial_return_value_ = NodeStatus::SUCCESS;
+    int counter_ = 0;
+};
+
+/**
+ * This test has a reactive sequence with a condition that return SUCCESS in the first tick and FAILURE in the second tick.
+ * The other child in the reactive sequence is an action with a retry decorator.
+ * The Action returns FAILURE in the first tick and SUCCESS in the second tick.
+ * The retry decorator has a max_attempts of 2.
+ *
+ * In the first tick, the condition returns SUCCESS, thus the action is ticked, but it returns FAILURE.
+ * Since the decorator is a retry, we expect it to return RUNNING.
+ * In the second tick, the condition return FAILURE, the retry should be halted and the action is not ticked.
+ * The result of the reactive sequence should be FAILURE.
+*/
+TEST(Retry, test)
+{
+  BT::ReactiveSequence root("root");
+  BT::RetryNode retry("retry", 2);
+  FlipN condition_1("condition_1", 1, NodeStatus::SUCCESS);
+  FlipN action_1("action_1", 1, NodeStatus::FAILURE);
+  root.addChild(&condition_1);
+  retry.setChild(&action_1);
+  root.addChild(&retry);
+
+  BT::NodeStatus status = root.executeTick();
+  ASSERT_EQ(status, BT::NodeStatus::RUNNING);
+
+  status = root.executeTick();
+  ASSERT_EQ(status, BT::NodeStatus::FAILURE);
+}
+
+


### PR DESCRIPTION
# Description
The `RetryUntilSuccessful` decorator retries the child on the SAME tick, thus it behaves like an independent tree, instead of forwarding the tick from the root. This behavior was unexpected for me.
For instance, consider the example below:

![image](https://github.com/BehaviorTree/BehaviorTree.CPP/assets/6097267/66a1c6ca-7bd5-4ab5-af13-9b2489774af9)

1) The condition succeeds once and then, on a second tick, it fails. 
2) Assume the action below the retry always fails.

I would expect the tree to exit on the second tick with `FAILURE`, because the condition would fail. However, the tree is stuck forever on the decorator (and blocked there).

I have added a unittest with the behavior I was expecting.

However, maybe this behavior change could affect a lot of users. so maybe we can discuss solutions?

thanks!
