### PR TITLE
Add optional metadata to TreeNodeManifest

### DIFF
--- a/include/behaviortree_cpp/basic_types.h
+++ b/include/behaviortree_cpp/basic_types.h
@@ -10,7 +10,9 @@
 #include <chrono>
 #include <memory>
 #include <string_view>
+#include <utility>
 #include <variant>
+#include <vector>
 #include <optional>
 
 #include "behaviortree_cpp/utils/safe_any.hpp"
@@ -450,6 +452,43 @@ struct has_static_method_description<
 {
 };
 
+/// Optional metadata for a TreeNodeManifest.
+/// The metadata can represent an xml element with text:
+///   <metadata_name>Descriptive text</metadata_name>
+/// Or an xml element with an attribute:
+///   <metadata_name attribute="value"/>
+struct ManifestMetadata
+{
+  /// A pair containing the <name, value> of a metadata's XML attribute.
+  using Attribute = std::pair<std::string, std::string>;
+
+  [[nodiscard]] bool representsText() const
+  {
+    return std::holds_alternative<std::string>(text_or_attribute);
+  }
+
+  [[nodiscard]] bool representsAttribute() const
+  {
+    return std::holds_alternative<Attribute>(text_or_attribute);
+  }
+
+  std::string name;
+  std::variant<std::string, Attribute> text_or_attribute;
+};
+
+template <typename T, typename = void>
+struct has_static_method_metadata : std::false_type
+{
+};
+
+template <typename T>
+struct has_static_method_metadata<
+    T, typename std::enable_if<
+           std::is_same<decltype(T::metadata()), std::vector<ManifestMetadata>>::value>::type>
+  : std::true_type
+{
+};
+
 template <typename T> [[nodiscard]]
 inline PortsList getProvidedPorts(enable_if<has_static_method_providedPorts<T>> = nullptr)
 {
@@ -467,4 +506,3 @@ using TimePoint = std::chrono::high_resolution_clock::time_point;
 using Duration = std::chrono::high_resolution_clock::duration;
 
 }   // namespace BT
-

--- a/include/behaviortree_cpp/bt_factory.h
+++ b/include/behaviortree_cpp/bt_factory.h
@@ -44,13 +44,20 @@ template <typename T>
 inline TreeNodeManifest CreateManifest(const std::string& ID,
                                        PortsList portlist = getProvidedPorts<T>())
 {
-  if constexpr( has_static_method_description<T>::value)
+  if constexpr( has_static_method_description<T>::value && has_static_method_metadata<T>::value )
   {
-    return {getType<T>(), ID, portlist, T::description()};
+    return {getType<T>(), ID, portlist, T::description(), T::metadata()};
   }
-  else {
-    return {getType<T>(), ID, portlist, {}};
+  else if constexpr( has_static_method_description<T>::value && !has_static_method_metadata<T>::value )
+  {
+    return {getType<T>(), ID, portlist, T::description(), {}};
   }
+  else if constexpr( !has_static_method_description<T>::value && has_static_method_metadata<T>::value )
+  {
+    return {getType<T>(), ID, portlist, {}, T::metadata()};
+  }
+
+  return {getType<T>(), ID, portlist, {}, {}};
 }
 
 #ifdef BT_PLUGIN_EXPORT

--- a/include/behaviortree_cpp/tree_node.h
+++ b/include/behaviortree_cpp/tree_node.h
@@ -17,6 +17,7 @@
 #include <exception>
 #include <mutex>
 #include <map>
+#include <vector>
 
 #include "behaviortree_cpp/utils/signal.h"
 #include "behaviortree_cpp/basic_types.h"
@@ -39,6 +40,7 @@ struct TreeNodeManifest
   std::string registration_ID;
   PortsList ports;
   std::string description;
+  std::vector<ManifestMetadata> metadata;
 };
 
 using PortsRemapping = std::unordered_map<std::string, std::string>;

--- a/src/bt_factory.cpp
+++ b/src/bt_factory.cpp
@@ -91,7 +91,7 @@ BehaviorTreeFactory::BehaviorTreeFactory():
   registerNodeType<SwitchNode<4>>("Switch4");
   registerNodeType<SwitchNode<5>>("Switch5");
   registerNodeType<SwitchNode<6>>("Switch6");
-  
+
   registerNodeType<LoopNode<int>>("LoopInt");
   registerNodeType<LoopNode<bool>>("LoopBool");
   registerNodeType<LoopNode<double>>("LoopDouble");
@@ -157,7 +157,7 @@ void BehaviorTreeFactory::registerSimpleCondition(
     return std::make_unique<SimpleConditionNode>(name, tick_functor, config);
   };
 
-  TreeNodeManifest manifest = {NodeType::CONDITION, ID, std::move(ports), {}};
+  TreeNodeManifest manifest = {NodeType::CONDITION, ID, std::move(ports), {}, {}};
   registerBuilder(manifest, builder);
 }
 
@@ -170,7 +170,7 @@ void BehaviorTreeFactory::registerSimpleAction(
     return std::make_unique<SimpleActionNode>(name, tick_functor, config);
   };
 
-  TreeNodeManifest manifest = {NodeType::ACTION, ID, std::move(ports), {}};
+  TreeNodeManifest manifest = {NodeType::ACTION, ID, std::move(ports), {}, {}};
   registerBuilder(manifest, builder);
 }
 
@@ -183,7 +183,7 @@ void BehaviorTreeFactory::registerSimpleDecorator(
     return std::make_unique<SimpleDecoratorNode>(name, tick_functor, config);
   };
 
-  TreeNodeManifest manifest = {NodeType::DECORATOR, ID, std::move(ports), {}};
+  TreeNodeManifest manifest = {NodeType::DECORATOR, ID, std::move(ports), {}, {}};
   registerBuilder(manifest, builder);
 }
 


### PR DESCRIPTION
Motivation: Users may want to specify additional data for a node ("metadata"). They now have the option to do this, and this "metadata" will be a part of the automatically created XML when calling [writeTreeNodesModelXML](https://github.com/BehaviorTree/BehaviorTree.CPP/blob/ceb25a7f78bc88b347d903b78969e2bd68f7df4b/src/xml_parsing.cpp#L1093).