### PR TITLE
Add unit test for switch node in combination with enum values

### DIFF
--- a/tests/gtest_enums.cpp
+++ b/tests/gtest_enums.cpp
@@ -89,3 +89,34 @@ TEST(Enums, StrintToEnum)
   }
 }
 
+TEST(Enums, SwitchNodeWithEnum)
+{
+  const std::string xml_txt = R"(
+    <root BTCPP_format="4" >
+      <BehaviorTree ID="Main">
+        <Sequence>
+          <Script code=" my_color := Blue "/>
+          <Switch4 variable="{my_color}"
+            case_1="{Red}"
+            case_2="{Blue}"
+            case_3="{Green}"
+            case_4="{Undefined}">
+            <AlwaysFailure name="case_red" />
+            <AlwaysSuccess name="case_blue" />
+            <AlwaysFailure name="case_green" />
+            <AlwaysFailure name="case_undefined" />
+            <AlwaysFailure name="default_case" />
+          </Switch4>
+        </Sequence>
+      </BehaviorTree>
+    </root>)";
+
+  BehaviorTreeFactory factory;
+  factory.registerScriptingEnums<Color>();
+
+  auto tree = factory.createTreeFromText(xml_txt);
+
+  NodeStatus status = tree.tickWhileRunning();
+
+  ASSERT_EQ(status, NodeStatus::SUCCESS);
+}


### PR DESCRIPTION
This PR adds a failing unit test for using an enum with the Switch node (see issue #710).

This test succeeds if you change line 98 in the test to

`<Script code=" my_color := 1 "/>`

and line 101 to

`case_2="1"`