### PR TITLE
switch some low-hanging fruit from 'const std::string&' to 'const StringView'

### DIFF
--- a/include/behaviortree_cpp/bt_factory.h
+++ b/include/behaviortree_cpp/bt_factory.h
@@ -42,14 +42,14 @@ inline NodeBuilder CreateBuilder(Args... args)
 }
 
 template <typename T>
-inline TreeNodeManifest CreateManifest(const std::string& ID,
+inline TreeNodeManifest CreateManifest(const StringView ID,
                                        PortsList portlist = getProvidedPorts<T>())
 {
   if constexpr( has_static_method_metadata<T>::value )
   {
-    return {getType<T>(), ID, portlist, T::metadata()};
+    return {getType<T>(), std::string(ID), portlist, T::metadata()};
   }
-  return {getType<T>(), ID, portlist, {}};
+  return {getType<T>(), std::string(ID), portlist, {}};
 }
 
 #ifdef BT_PLUGIN_EXPORT
@@ -320,7 +320,7 @@ public:
    *  Doesn't require the implementation of static method providedPorts()
   */
   template <typename T, typename... ExtraArgs>
-  void registerNodeType(const std::string& ID, const PortsList& ports, ExtraArgs... args)
+  void registerNodeType(const StringView ID, const PortsList& ports, ExtraArgs... args)
   {
     static_assert(std::is_base_of<ActionNodeBase, T>::value ||
                   std::is_base_of<ControlNode, T>::value ||
@@ -356,7 +356,7 @@ public:
   *  ControlNode or ConditionNode.
   */
   template <typename T, typename... ExtraArgs>
-  void registerNodeType(const std::string& ID, ExtraArgs... args)
+  void registerNodeType(const StringView ID, ExtraArgs... args)
   {
     if constexpr(std::is_abstract_v<T>) {
       // check first if the given class is abstract

--- a/include/behaviortree_cpp/tree_node.h
+++ b/include/behaviortree_cpp/tree_node.h
@@ -131,7 +131,7 @@ public:
      *
      *     static PortsList providedPorts();
      */
-  TreeNode(std::string name, NodeConfig config);
+  TreeNode(const StringView name, NodeConfig config);
 
   TreeNode(const TreeNode& other) = delete;
   TreeNode& operator=(const TreeNode& other) = delete;

--- a/src/bt_factory.cpp
+++ b/src/bt_factory.cpp
@@ -157,7 +157,7 @@ void BehaviorTreeFactory::registerSimpleCondition(
     return std::make_unique<SimpleConditionNode>(name, tick_functor, config);
   };
 
-  TreeNodeManifest manifest = {NodeType::CONDITION, ID, std::move(ports), {}};
+  TreeNodeManifest manifest = {NodeType::CONDITION, std::string(ID), std::move(ports), {}};
   registerBuilder(manifest, builder);
 }
 
@@ -170,7 +170,7 @@ void BehaviorTreeFactory::registerSimpleAction(
     return std::make_unique<SimpleActionNode>(name, tick_functor, config);
   };
 
-  TreeNodeManifest manifest = {NodeType::ACTION, ID, std::move(ports), {}};
+  TreeNodeManifest manifest = {NodeType::ACTION, std::string(ID), std::move(ports), {}};
   registerBuilder(manifest, builder);
 }
 
@@ -183,7 +183,7 @@ void BehaviorTreeFactory::registerSimpleDecorator(
     return std::make_unique<SimpleDecoratorNode>(name, tick_functor, config);
   };
 
-  TreeNodeManifest manifest = {NodeType::DECORATOR, ID, std::move(ports), {}};
+  TreeNodeManifest manifest = {NodeType::DECORATOR, std::string(ID), std::move(ports), {}};
   registerBuilder(manifest, builder);
 }
 

--- a/src/tree_node.cpp
+++ b/src/tree_node.cpp
@@ -20,8 +20,8 @@ namespace BT
 
 struct TreeNode::PImpl
 {
-  PImpl(std::string name, NodeConfig config):
-    name(std::move(name)),
+  PImpl(StringView name, NodeConfig config):
+    name(name),
     config(std::move(config))
   {}
 
@@ -52,8 +52,8 @@ struct TreeNode::PImpl
 };
 
 
-TreeNode::TreeNode(std::string name, NodeConfig config) :
-  _p(new PImpl(std::move(name), std::move(config)))
+TreeNode::TreeNode(StringView name, NodeConfig config) :
+  _p(new PImpl(name, std::move(config)))
 {
 }
 
@@ -322,7 +322,7 @@ uint16_t TreeNode::UID() const
   return _p->config.uid;
 }
 
-const std::string &TreeNode::fullPath() const
+const std::string& TreeNode::fullPath() const
 {
   return _p->config.path;
 }
@@ -332,12 +332,12 @@ const std::string& TreeNode::registrationName() const
   return _p->registration_ID;
 }
 
-const NodeConfig &TreeNode::config() const
+const NodeConfig& TreeNode::config() const
 {
   return _p->config;
 }
 
-NodeConfig &TreeNode::config()
+NodeConfig& TreeNode::config()
 {
   return _p->config;
 }
@@ -483,7 +483,7 @@ std::string toStr<PostCond>(const PostCond& pre)
   }
 }
 
-AnyPtrLocked BT::TreeNode::getLockedPortContent(const std::string &key)
+AnyPtrLocked BT::TreeNode::getLockedPortContent(const std::string& key)
 {
   if(auto remapped_key = getRemappedKey(key, getRawPortValue(key)))
   {


### PR DESCRIPTION
const std::string& runs deep...hard to change a whole lot without making breaking changes to or extending the API. This should 'fix' #758 which is all I was really after.

Is updating the signature of everyone's constructors to take StringView instead of std::string& worth working on?