### PR TITLE
Emscripten support for BehaviorTree.CPP

### DIFF
--- a/include/behaviortree_cpp/action_node.h
+++ b/include/behaviortree_cpp/action_node.h
@@ -186,6 +186,8 @@ private:
   std::atomic_bool halt_requested_;
 };
 
+#ifndef __EMSCRIPTEN__
+
 /**
  * @brief The CoroActionNode class is an a good candidate for asynchronous actions
  * which need to communicate with an external service using an async request/reply interface.
@@ -228,6 +230,7 @@ protected:
   void destroyCoroutine();
 };
 
+#endif
 
 }   // namespace BT
 

--- a/src/action_node.cpp
+++ b/src/action_node.cpp
@@ -11,8 +11,11 @@
 *   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+#ifndef __EMSCRIPTEN__
 #define MINICORO_IMPL
 #include "minicoro/minicoro.h"
+#endif
+
 #include "behaviortree_cpp/action_node.h"
 
 using namespace BT;
@@ -64,6 +67,7 @@ NodeStatus SyncActionNode::executeTick()
 }
 
 //-------------------------------------
+#ifdef MINICORO_IMPL
 
 struct CoroActionNode::Pimpl
 {
@@ -145,6 +149,7 @@ void CoroActionNode::destroyCoroutine()
   }
 }
 
+#endif
 
 bool StatefulActionNode::isHaltRequested() const
 {


### PR DESCRIPTION
## Changes

- Removed compile errors that crop up when compiling with emsdk 3.1.47
- MiniCoro library errors
```
D:\CustomBuilds\emsdk\upstream\emscripten\cache\sysroot/include\emscripten/em_asm.h:152:1: error: templates must have C++ linkage
  152 | template<typename, typename = void> struct __em_asm_sig {};
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../3rdparty\minicoro/minicoro.h:310:1: note: extern "C" language linkage specification begins here
  310 | extern "C" {
  ```
  
  Linked to issue: #679 
  
 ## Compiled on Windows with
 
 - emsdk activate
 - `emcmake cmake -B build -G Ninja -DBTCPP_SHARED_LIBS=OFF -DBTCPP_BUILD_TOOLS=OFF -DBTCPP_UNIT_TESTS=OFF -DBTCPP_GROOT_INTERFACE=OFF -DBTCPP_SQLITE_LOGGING=OFF`