### PR TITLE
depend only on libboost-coroutine(-dev) for v3.8

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -22,7 +22,8 @@
   <depend condition="$ROS_VERSION == 2">rclcpp</depend>
   <depend condition="$ROS_VERSION == 2">ament_index_cpp</depend>
 
-  <depend>boost</depend>
+  <build_depend>libboost-coroutine-dev</build_depend>
+  <exec_depend>libboost-coroutine</exec_depend>
   <depend>libzmq3-dev</depend>
   <depend>libncurses-dev</depend>
 


### PR DESCRIPTION
At least on Ubuntu, boost-all-dev depends on openmpi, which depends on a fortran compiler and gcc. This is quite heavy for Docker containers where only exec dependencies are really needed.

Rosdep now has entries for finer-grained boost dependencies, so using those, a lot fewer packages will be installed.

Rough numbers ontop of `ros:iron-ros-core`:

- libboost-all-dev: ~600MB disk space
- libboost-coroutine-dev: ~250MB disk space
- libboost-coroutine1.74.0: <1MB

I'm not 100% sure how this interacts with the .deb packaging process, but even using

```
<depend>libboost-coroutine-dev</depend>
```

would be quite an improvement.