### PR TITLE
Initialize all instances of `std::atomic_bool`

### DIFF
--- a/examples/broken_sequence.cpp
+++ b/examples/broken_sequence.cpp
@@ -35,7 +35,7 @@ public:
 
 private:
   int time_;
-  std::atomic_bool stop_loop_;
+  std::atomic_bool stop_loop_ = false;
 };
 
 int main()

--- a/include/behaviortree_cpp/action_node.h
+++ b/include/behaviortree_cpp/action_node.h
@@ -132,7 +132,7 @@ public:
 
 private:
   std::exception_ptr exptr_;
-  std::atomic_bool halt_requested_;
+  std::atomic_bool halt_requested_ = false;
   std::future<void> thread_handle_;
   std::mutex mutex_;
 };
@@ -183,7 +183,7 @@ protected:
   void halt() override final;
 
 private:
-  std::atomic_bool halt_requested_;
+  std::atomic_bool halt_requested_ = false;
 };
 
 /**

--- a/include/behaviortree_cpp/actions/sleep_node.h
+++ b/include/behaviortree_cpp/actions/sleep_node.h
@@ -38,7 +38,7 @@ private:
   TimerQueue<> timer_;
   uint64_t timer_id_;
 
-  std::atomic_bool timer_waiting_;
+  std::atomic_bool timer_waiting_ = false;
   std::mutex delay_mutex_;
 };
 

--- a/include/behaviortree_cpp/actions/test_node.h
+++ b/include/behaviortree_cpp/actions/test_node.h
@@ -88,7 +88,7 @@ private:
   TestNodeConfig _test_config;
   ScriptFunction _executor;
   TimerQueue<> _timer;
-  std::atomic_bool _completed;
+  std::atomic_bool _completed = false;
 };
 
 }   // namespace BT

--- a/include/behaviortree_cpp/decorators/delay_node.h
+++ b/include/behaviortree_cpp/decorators/delay_node.h
@@ -56,11 +56,11 @@ private:
 
   virtual BT::NodeStatus tick() override;
 
-  bool delay_started_;
-  std::atomic_bool delay_complete_;
-  bool delay_aborted_;
+  bool delay_started_ = false;
+  std::atomic_bool delay_complete_ = false;
+  bool delay_aborted_ = false;
   unsigned msec_;
-  bool read_parameter_from_ports_;
+  bool read_parameter_from_ports_ = false;
   std::mutex delay_mutex_;
 };
 

--- a/include/behaviortree_cpp/decorators/timeout_node.h
+++ b/include/behaviortree_cpp/decorators/timeout_node.h
@@ -73,7 +73,7 @@ private:
   void halt() override;
 
   TimerQueue<> timer_;
-  std::atomic_bool child_halted_;
+  std::atomic_bool child_halted_ = false;
   uint64_t timer_id_;
 
   unsigned msec_;

--- a/src/loggers/groot2_publisher.cpp
+++ b/src/loggers/groot2_publisher.cpp
@@ -73,7 +73,7 @@ struct Groot2Publisher::PImpl
 
   std::string tree_xml;
 
-  std::atomic_bool active_server;
+  std::atomic_bool active_server = false;
   std::thread server_thread;
 
   std::mutex status_mutex;


### PR DESCRIPTION
I have been testing a sequence of behaviors based on the `StatefulActionNode` and noticed that sometimes my behaviors would immediately return because the value of `isHaltRequested()` was checked in the `onRunning()` method. After some digging I found that the value  `halt_requested_` is uninitialized and set to a random value when constructing my `StatefulActionNode` based objects.

I added a simple print statement to the constructor of `StatefulActionNode` and this is what I found:
```
[node_main] StatefulActionNode: halt_requested_ = 0
[node_main] StatefulActionNode: halt_requested_ = 1
[node_main] StatefulActionNode: halt_requested_ = 1
[node_main] StatefulActionNode: halt_requested_ = 0
[node_main] StatefulActionNode: halt_requested_ = 1
[node_main] StatefulActionNode: halt_requested_ = 1
[node_main] StatefulActionNode: halt_requested_ = 0
[node_main] StatefulActionNode: halt_requested_ = 1
[node_main] StatefulActionNode: halt_requested_ = 1
[node_main] StatefulActionNode: halt_requested_ = 1
[node_main] StatefulActionNode: halt_requested_ = 1
[node_main] StatefulActionNode: halt_requested_ = 1
[node_main] : Sequence IDLE -> RUNNING
....
```

This PR initializes all instances of `std::atomic_bool` and a handful of `bool` member variables. I would think it's best practice to initialize all member variables but wanted to push this up and get your thoughts before investing more time.

