### PR TITLE
Extend unit test for blackboard backup to run the second tree

### DIFF
--- a/tests/gtest_blackboard.cpp
+++ b/tests/gtest_blackboard.cpp
@@ -515,18 +515,20 @@ TEST(BlackboardTest, BlackboardBackup)
   <root BTCPP_format="4" >
     <BehaviorTree ID="MySubtree">
       <Sequence>
-        <Script code=" value:= sub_value " />
-        <Script code=" my_value=2 " />
+        <Script code=" important_value:= sub_value " />
+        <Script code=" my_value=false " />
+        <SaySomething message="{message}" />
       </Sequence>
     </BehaviorTree>
     <BehaviorTree ID="MainTree">
       <Sequence>
-        <Script code=" my_value:=1 " />
-        <SubTree ID="MySubtree" sub_value="true" _autoremap="true" />
+        <Script code=" my_value:=true; another_value:='hi' " />
+        <SubTree ID="MySubtree" sub_value="true" message="{another_value}" _autoremap="true" />
       </Sequence>
     </BehaviorTree>
   </root> )";
 
+  factory.registerNodeType<DummyNodes::SaySomething>("SaySomething");
   factory.registerBehaviorTreeFromText(xml_text);
   auto tree = factory.createTree("MainTree");
 
@@ -556,4 +558,6 @@ TEST(BlackboardTest, BlackboardBackup)
       ASSERT_EQ(expected_keys[i][a], keys[a]);
     }
   }
+  status = tree.tickWhileRunning();
+  ASSERT_EQ(status, BT::NodeStatus::SUCCESS);
 }


### PR DESCRIPTION
<!--
You must run clang-format, otherwise your change may not pass the tests on CI
We recommend using pre-commit.

To use:
    pre-commit run -a
Or:
     pre-commit install  # (runs every time you commit in git)

See https://github.com/pre-commit/pre-commit
-->

Extended the Unit testing of the Blackboard Backup to run the second iteration of the tree after the blackboard restore. Some blackboard variables are not being remapped correctly to the Subtree
