### PR TITLE
Add option to use third party as external dependencies

### DIFF
--- a/.github/workflows/cmake_ubuntu.yml
+++ b/.github/workflows/cmake_ubuntu.yml
@@ -24,13 +24,10 @@ jobs:
       id: conan
       uses: turtlebrowser/get-conan@main
       with:
-        version: 1.59.0
+        version: 2.2.1
 
     - name: Create default profile
-      run: conan profile new default --detect
-
-    - name: Update profile
-      run: conan profile update settings.compiler.libcxx=libstdc++11 default
+      run: conan profile detect
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory
@@ -57,3 +54,39 @@ jobs:
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
+
+  unvendor_build:
+    # Validate the CMake option BTCPP_VENDOR_3RDPARTY. Should be able to external dependencies only.
+    # cppzmq is the only exception because is patched by us.
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Conan
+      id: conan
+      uses: turtlebrowser/get-conan@main
+      with:
+        version: 2.2.1
+
+    - name: Create default profile
+      run: conan profile detect
+
+    - name: Create Build Environment
+      # Some projects don't allow in-source building, so create a separate build directory
+      # We'll use this as our working directory for all subsequent commands
+      run: cmake -E make_directory ${{github.workspace}}/build
+
+    - name: Install conan dependencies
+      working-directory: ${{github.workspace}}/build
+      run: conan install ${{github.workspace}}/conanfile.txt -s build_type=${{env.BUILD_TYPE}} --build=missing
+
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{github.workspace}}/build
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBTCPP_VENDOR_3RDPARTY=OFF -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake
+
+    - name: Build
+      shell: bash
+      working-directory: ${{github.workspace}}/build
+      run: cmake --build . --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/cmake_ubuntu.yml
+++ b/.github/workflows/cmake_ubuntu.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Install conan dependencies
       working-directory: ${{github.workspace}}/build
-      run: conan install ${{github.workspace}}/conanfile.txt -s build_type=${{env.BUILD_TYPE}} --build=missing
+      run: conan install ${{github.workspace}}/conanfile.txt -s build_type=${{env.BUILD_TYPE}} -s compiler.cppstd=17 --build=missing
 
     - name: Configure CMake
       shell: bash
@@ -79,7 +79,7 @@ jobs:
 
     - name: Install conan dependencies
       working-directory: ${{github.workspace}}/build
-      run: conan install ${{github.workspace}}/conanfile.txt -s build_type=${{env.BUILD_TYPE}} --build=missing
+      run: conan install ${{github.workspace}}/conanfile.txt -s build_type=${{env.BUILD_TYPE}} -s compiler.cppstd=17 --build=missing
 
     - name: Configure CMake
       shell: bash

--- a/.github/workflows/cmake_windows.yml
+++ b/.github/workflows/cmake_windows.yml
@@ -24,10 +24,10 @@ jobs:
       id: conan
       uses: turtlebrowser/get-conan@main
       with:
-        version: 1.59.0
+        version: 2.2.1
 
     - name: Create default profile
-      run: conan profile new default --detect
+      run: conan profile detect
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory
@@ -36,7 +36,7 @@ jobs:
 
     - name: Install conan dependencies
       working-directory: ${{github.workspace}}/build
-      run: conan install ${{github.workspace}}/conanfile.txt -s build_type=${{env.BUILD_TYPE}} --build=missing
+      run: conan install ${{github.workspace}}/conanfile.txt -s build_type=${{env.BUILD_TYPE}} -s compiler.cppstd=17 --build=missing
 
     - name: Configure CMake
       shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,8 +81,6 @@ endif()
 
 if (BTCPP_VENDOR_3RDPARTY)
     add_subdirectory(3rdparty/lexy)
-else()
-    find_package(lexy CONFIG REQUIRED)
 endif()
 
 list(APPEND BT_SOURCE
@@ -126,8 +124,8 @@ list(APPEND BT_SOURCE
     src/loggers/bt_minitrace_logger.cpp
     src/loggers/bt_observer.cpp
 
-    3rdparty/tinyxml2/tinyxml2.cpp
-    3rdparty/minitrace/minitrace.cpp
+    $<IF:$<BOOL:${BTCPP_VENDOR_3RDPARTY}>,${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tinyxml2/tinyxml2.cpp,>
+    $<IF:$<BOOL:${BTCPP_VENDOR_3RDPARTY}>,${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/minitrace/minitrace.cpp,>
     )
 
 
@@ -165,7 +163,7 @@ target_link_libraries(${BTCPP_LIBRARY}
     PRIVATE
         Threads::Threads
         ${CMAKE_DL_LIBS}
-        $<BUILD_INTERFACE:foonathan::lexy>
+        $<IF:$<BOOL:${BTCPP_VENDOR_3RDPARTY}>,$<BUILD_INTERFACE:foonathan::lexy>,>
         ${BTCPP_EXTRA_LIBRARIES}
 )
 
@@ -176,6 +174,10 @@ target_include_directories(${BTCPP_LIBRARY}
     PRIVATE
         $<IF:$<BOOL:${BTCPP_VENDOR_3RDPARTY}>,${CMAKE_CURRENT_SOURCE_DIR}/3rdparty,>
         $<IF:$<BOOL:${BTCPP_VENDOR_3RDPARTY}>,${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/lexy/include,>
+        $<IF:$<BOOL:${BTCPP_VENDOR_3RDPARTY}>,${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tinyxml2,>
+        $<IF:$<BOOL:${BTCPP_VENDOR_3RDPARTY}>,${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/minitrace,>
+        $<IF:$<BOOL:${BTCPP_VENDOR_3RDPARTY}>,${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/wildcards,>
+        $<IF:$<BOOL:${BTCPP_VENDOR_3RDPARTY}>,${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/minicoro,>
         ${BTCPP_EXTRA_INCLUDE_DIRS}
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,8 +174,8 @@ target_include_directories(${BTCPP_LIBRARY}
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
     PRIVATE
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/3rdparty>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/lexy/include>
+        $<IF:$<BOOL:${BTCPP_VENDOR_3RDPARTY}>,${CMAKE_CURRENT_SOURCE_DIR}/3rdparty,>
+        $<IF:$<BOOL:${BTCPP_VENDOR_3RDPARTY}>,${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/lexy/include,>
         ${BTCPP_EXTRA_INCLUDE_DIRS}
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,7 +172,7 @@ target_include_directories(${BTCPP_LIBRARY}
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
     PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/3rdparty>
         $<IF:$<BOOL:${BTCPP_VENDOR_3RDPARTY}>,${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/lexy/include,>
         $<IF:$<BOOL:${BTCPP_VENDOR_3RDPARTY}>,${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tinyxml2,>
         $<IF:$<BOOL:${BTCPP_VENDOR_3RDPARTY}>,${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/minitrace,>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ target_link_libraries(${BTCPP_LIBRARY}
     PRIVATE
         Threads::Threads
         ${CMAKE_DL_LIBS}
-        $<IF:$<BOOL:${BTCPP_VENDOR_3RDPARTY}>,$<BUILD_INTERFACE:foonathan::lexy>,>
+        $<BUILD_INTERFACE:foonathan::lexy>
         ${BTCPP_EXTRA_LIBRARIES}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,7 +172,7 @@ target_include_directories(${BTCPP_LIBRARY}
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
     PRIVATE
-        $<IF:$<BOOL:${BTCPP_VENDOR_3RDPARTY}>,${CMAKE_CURRENT_SOURCE_DIR}/3rdparty,>
+        ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty
         $<IF:$<BOOL:${BTCPP_VENDOR_3RDPARTY}>,${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/lexy/include,>
         $<IF:$<BOOL:${BTCPP_VENDOR_3RDPARTY}>,${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tinyxml2,>
         $<IF:$<BOOL:${BTCPP_VENDOR_3RDPARTY}>,${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/minitrace,>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ option(BTCPP_EXAMPLES   "Build tutorials and examples" ON)
 option(BTCPP_UNIT_TESTS "Build the unit tests" ON)
 option(BTCPP_GROOT_INTERFACE "Add Groot2 connection. Requires ZeroMQ" ON)
 option(BTCPP_SQLITE_LOGGING "Add SQLite logging." ON)
+option(BTCPP_VENDOR_3RDPARTY "Use the 3rdparty libraries in the vendor folder" ON)
 
 option(USE_V3_COMPATIBLE_NAMES  "Use some alias to compile more easily old 3.x code" OFF)
 
@@ -78,7 +79,11 @@ endif()
 #############################################################
 # LIBRARY
 
-add_subdirectory(3rdparty/lexy)
+if (BTCPP_VENDOR_3RDPARTY)
+    add_subdirectory(3rdparty/lexy)
+else()
+    find_package(lexy CONFIG REQUIRED)
+endif()
 
 list(APPEND BT_SOURCE
     src/action_node.cpp

--- a/cmake/conan_build.cmake
+++ b/cmake/conan_build.cmake
@@ -20,7 +20,7 @@ if (NOT BTCPP_VENDOR_3RDPARTY)
     find_package(wildcards REQUIRED)
     find_package(tinyxml2 REQUIRED)
 
-    list(APPEND BTCPP_EXTRA_LIBRARIES foonathan::lexy minicoro::minicoro minitrace::minitrace wildcards::wildcards tinyxml2::tinyxml2)
+    list(APPEND BTCPP_EXTRA_LIBRARIES minicoro::minicoro minitrace::minitrace wildcards::wildcards tinyxml2::tinyxml2)
     list(APPEND BTCPP_EXTRA_INCLUDE_DIRS ${lexy_INCLUDE_DIRS} ${minicoro_INCLUDE_DIRS} ${minitrace_INCLUDE_DIRS} ${wildcards_INCLUDE_DIRS} ${tinyxml2_INCLUDE_DIRS})
 endif()
 

--- a/cmake/conan_build.cmake
+++ b/cmake/conan_build.cmake
@@ -2,15 +2,26 @@ list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}")
 
 if(BTCPP_GROOT_INTERFACE)
     find_package(ZeroMQ REQUIRED)
-    list(APPEND BTCPP_EXTRA_LIBRARIES ${ZeroMQ_LIBRARIES})
+    list(APPEND BTCPP_EXTRA_LIBRARIES $<IF:$<TARGET_EXISTS:libzmq-static>, libzmq-static, libzmq-shared>)
     list(APPEND BTCPP_EXTRA_INCLUDE_DIRS ${ZeroMQ_INCLUDE_DIRS})
     message(STATUS "ZeroMQ_LIBRARIES: ${ZeroMQ_LIBRARIES}")
 endif()
 
 if(BTCPP_SQLITE_LOGGING)
     find_package(SQLite3 REQUIRED)
-    list(APPEND BTCPP_EXTRA_LIBRARIES ${SQLite3_LIBRARIES})
+    list(APPEND BTCPP_EXTRA_LIBRARIES SQLite::SQLite3)
     message(STATUS "SQLite3_LIBRARIES: ${SQLite3_LIBRARIES}")
+endif()
+
+if (NOT BTCPP_VENDOR_3RDPARTY)
+    find_package(lexy CONFIG REQUIRED)
+    find_package(minicoro REQUIRED)
+    find_package(minitrace REQUIRED)
+    find_package(wildcards REQUIRED)
+    find_package(tinyxml2 REQUIRED)
+
+    list(APPEND BTCPP_EXTRA_LIBRARIES foonathan::lexy minicoro::minicoro minitrace::minitrace wildcards::wildcards tinyxml2::tinyxml2)
+    list(APPEND BTCPP_EXTRA_INCLUDE_DIRS ${lexy_INCLUDE_DIRS} ${minicoro_INCLUDE_DIRS} ${minitrace_INCLUDE_DIRS} ${wildcards_INCLUDE_DIRS} ${tinyxml2_INCLUDE_DIRS})
 endif()
 
 

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,4 +1,4 @@
-[tool_requires]
+[test_requires]
 gtest/1.14.0
 
 [requires]

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,7 +1,14 @@
-[requires]
+[tool_requires]
 gtest/1.14.0
-zeromq/4.3.4
-sqlite3/3.40.1
+
+[requires]
+foonathan-lexy/2022.12.1
+zeromq/4.3.5
+sqlite3/3.45.2
+minicoro/0.1.3
+minitrace/cci.20230905
+wildcards/1.4.0
+tinyxml2/10.0.0
 
 [generators]
 CMakeDeps

--- a/src/action_node.cpp
+++ b/src/action_node.cpp
@@ -12,7 +12,7 @@
 */
 
 #define MINICORO_IMPL
-#include "minicoro/minicoro.h"
+#include "minicoro.h"
 #include "behaviortree_cpp/action_node.h"
 
 using namespace BT;

--- a/src/bt_factory.cpp
+++ b/src/bt_factory.cpp
@@ -15,7 +15,7 @@
 #include "behaviortree_cpp/utils/shared_library.h"
 #include "behaviortree_cpp/contrib/json.hpp"
 #include "behaviortree_cpp/xml_parsing.h"
-#include "wildcards/wildcards.hpp"
+#include "wildcards.hpp"
 
 #ifdef USING_ROS
 #include <ros/package.h>

--- a/src/loggers/bt_minitrace_logger.cpp
+++ b/src/loggers/bt_minitrace_logger.cpp
@@ -2,7 +2,7 @@
 #include "behaviortree_cpp/loggers/bt_minitrace_logger.h"
 
 #define MTR_ENABLED true
-#include "minitrace/minitrace.h"
+#include "minitrace.h"
 
 namespace BT
 {

--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -26,7 +26,7 @@
 
 #include <map>
 #include "behaviortree_cpp/xml_parsing.h"
-#include "tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include <filesystem>
 
 #ifdef USING_ROS

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set(BT_TESTS
 set(TEST_DEPENDECIES
     ${BTCPP_LIBRARY}
     foonathan::lexy
+    $<IF:$<NOT:$<BOOL:${BTCPP_VENDOR_3RDPARTY}>>,wildcards::wildcards,>
     bt_sample_nodes)
 
 if(ament_cmake_FOUND AND BUILD_TESTING)

--- a/tests/gtest_match.cpp
+++ b/tests/gtest_match.cpp
@@ -1,5 +1,5 @@
 #include <gtest/gtest.h>
-#include "wildcards/wildcards.hpp"
+#include "wildcards.hpp"
 
 TEST(Match, Match)
 {


### PR DESCRIPTION
Greetings!

After the PR https://github.com/conan-io/conan-center-index/pull/20010, I checked a little bit the current state of BehaviorTree, and there is a window to use external dependencies, instead of those vendorized versions. The only exception is for cppzmq, because it has an internal patch. But why moving to external dependencies, if vendorized is working and keeps versions aligned? Well, people will be able to use newer versions, or even use customized versions, without touching this project.

To summarize this PR:

- Add the CMake option BTCPP_VENDOR_3RDPARTY. By default, it will be ON, and will follow the very same behavior as in master branch right now: Consumed all dependencies from 3rdparty folder. When using as OFF, it will use external instead, including:
  - foonathan-lexy/2022.12.1
  - zeromq/4.3.5
  - sqlite3/3.45.2
  - minicoro/0.1.3
  - minitrace/cci.20230905
  - wildcards/1.4.0
  - tinyxml2/10.0.0
  - gtest/1.14.0
  - cppzmq will be from 3rdparty folder always! 

For now, I only checked it with Conan, but could be agnostic, by adding a `find_package()` in CMakeLists.txt and changing the `target_link_libraries`, but would requires more changes, harder to review, but could be a next PR. 

- Change the import headers to not use namespace for some dependencies. Well, sounds contradictory, but real thing is, all those projects install their headers in `include` folder directly, no namespace folder, even their tests and examples are using on that way. Here is some information:

  - minicoro: https://github.com/edubart/minicoro?tab=readme-ov-file#minimal-example
  - wildcards: https://github.com/zemasoft/wildcards?tab=readme-ov-file#basic-usage
  - minitrace: https://github.com/hrydgard/minitrace/blob/master/CMakeLists.txt#L37
  - tinyxml2: https://github.com/leethomason/tinyxml2/blob/master/CMakeLists.txt#L81

- I tested on my machine™, but as it's irrelevant to the future, I added a new CI job to only 
build the project (including unit tests) using only external dependencies. Plus, I updated to use Conan 2.x (Conan 1.x is to be deprecated in the future.)
