### PR TITLE
Add string concatenation operator to scripting

### DIFF
--- a/include/behaviortree_cpp/scripting/operators.hpp
+++ b/include/behaviortree_cpp/scripting/operators.hpp
@@ -150,6 +150,7 @@ struct ExprBinaryArithmetic : ExprBase
     minus,
     times,
     div,
+    concat,
 
     bit_and,
     bit_or,
@@ -171,6 +172,8 @@ struct ExprBinaryArithmetic : ExprBase
         return "*";
       case div:
         return "/";
+      case concat:
+        return "..";
       case bit_and:
         return "&";
       case bit_or:
@@ -273,6 +276,12 @@ struct ExprBinaryArithmetic : ExprBase
       }
     }
     else if(rhs_v.isString() && lhs_v.isString() && op == plus)
+    {
+      return Any(lhs_v.cast<std::string>() + rhs_v.cast<std::string>());
+    }
+    else if (op == concat && ((rhs_v.isString() && lhs_v.isString()) ||
+                            (rhs_v.isString() && lhs_v.isNumber()) ||
+                            (rhs_v.isNumber() && lhs_v.isString())))
     {
       return Any(lhs_v.cast<std::string>() + rhs_v.cast<std::string>());
     }
@@ -722,6 +731,16 @@ struct Expression : lexy::expression_production
     using operand = math_product;
   };
 
+  // x .. y
+  struct string_concat : dsl::infix_op_left
+  {
+    static constexpr auto op = [] {
+      return dsl::op<Ast::ExprBinaryArithmetic::concat>(LEXY_LIT(".."));
+    }();
+    
+    using operand = math_sum;
+  };
+
   // ~x
   struct bit_prefix : dsl::prefix_op
   {
@@ -785,7 +804,7 @@ struct Expression : lexy::expression_production
         dsl::op<Ast::ExprBinaryArithmetic::logic_or>(LEXY_LIT("||")) /
         dsl::op<Ast::ExprBinaryArithmetic::logic_and>(LEXY_LIT("&&"));
 
-    using operand = comparison;
+    using operand = dsl::groups<string_concat, comparison>;
   };
 
   // x ? y : z


### PR DESCRIPTION
Helps address #766 but just supports string concatenation resulting in a string.

Adds support for string concatenation via a new operator, similar to how it is done in Lua:

e.g.
```
value := 10
message := "The value is " .. value
```
would result in `The value is 10`

Haven't gone much further than testing for my own use case. I can make some other changes if required so please let me know :)