### PR TITLE
[DRAFT] Stamped blackboard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,9 @@ list(APPEND BT_SOURCE
     src/decorators/repeat_node.cpp
     src/decorators/retry_node.cpp
     src/decorators/timeout_node.cpp
+    src/decorators/skip_unless_updated.cpp
     src/decorators/subtree_node.cpp
+    src/decorators/wait_update.cpp
 
     src/controls/if_then_else_node.cpp
     src/controls/fallback_node.cpp
@@ -148,7 +150,8 @@ endif()
 
 if (BTCPP_SHARED_LIBS)
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-    add_library(${BTCPP_LIBRARY} SHARED ${BT_SOURCE})
+    add_library(${BTCPP_LIBRARY} SHARED ${BT_SOURCE}
+        src/decorators/wait_update.cpp)
 else()
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
     add_library(${BTCPP_LIBRARY} STATIC ${BT_SOURCE})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,8 +150,7 @@ endif()
 
 if (BTCPP_SHARED_LIBS)
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-    add_library(${BTCPP_LIBRARY} SHARED ${BT_SOURCE}
-        src/decorators/wait_update.cpp)
+    add_library(${BTCPP_LIBRARY} SHARED ${BT_SOURCE})
 else()
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
     add_library(${BTCPP_LIBRARY} STATIC ${BT_SOURCE})

--- a/include/behaviortree_cpp/basic_types.h
+++ b/include/behaviortree_cpp/basic_types.h
@@ -335,10 +335,8 @@ using Result = Expected<std::monostate>;
 struct Timestamp
 {
   uint64_t seq = 0;
-  std::chrono::nanoseconds stamp = std::chrono::nanoseconds(0);
+  std::chrono::nanoseconds time = std::chrono::nanoseconds(0);
 };
-
-using ResultStamped = Expected<Timestamp>;
 
 [[nodiscard]] bool IsAllowedPortName(StringView str);
 

--- a/include/behaviortree_cpp/basic_types.h
+++ b/include/behaviortree_cpp/basic_types.h
@@ -332,6 +332,14 @@ using Optional = nonstd::expected<T, std::string>;
  * */
 using Result = Expected<std::monostate>;
 
+struct Timestamp
+{
+  uint64_t seq = 0;
+  std::chrono::nanoseconds stamp = std::chrono::nanoseconds(0);
+};
+
+using ResultStamped = Expected<Timestamp>;
+
 [[nodiscard]] bool IsAllowedPortName(StringView str);
 
 class TypeInfo

--- a/include/behaviortree_cpp/basic_types.h
+++ b/include/behaviortree_cpp/basic_types.h
@@ -334,7 +334,9 @@ using Result = Expected<std::monostate>;
 
 struct Timestamp
 {
+  // Number being incremented every time a new value is written
   uint64_t seq = 0;
+  // Last update time. Nanoseconds since epoch
   std::chrono::nanoseconds time = std::chrono::nanoseconds(0);
 };
 

--- a/include/behaviortree_cpp/behavior_tree.h
+++ b/include/behaviortree_cpp/behavior_tree.h
@@ -33,6 +33,8 @@
 #include "behaviortree_cpp/decorators/run_once_node.h"
 #include "behaviortree_cpp/decorators/subtree_node.h"
 #include "behaviortree_cpp/decorators/loop_node.h"
+#include "behaviortree_cpp/decorators/skip_unless_updated.h"
+#include "behaviortree_cpp/decorators/wait_update.h"
 
 #include "behaviortree_cpp/actions/always_success_node.h"
 #include "behaviortree_cpp/actions/always_failure_node.h"

--- a/include/behaviortree_cpp/bt_factory.h
+++ b/include/behaviortree_cpp/bt_factory.h
@@ -14,14 +14,11 @@
 #ifndef BT_FACTORY_H
 #define BT_FACTORY_H
 
-#include <algorithm>
-#include <cstring>
 #include <filesystem>
 #include <functional>
 #include <memory>
 #include <unordered_map>
 #include <set>
-#include <utility>
 #include <vector>
 
 #include "behaviortree_cpp/contrib/magic_enum.hpp"

--- a/include/behaviortree_cpp/decorators/skip_unless_updated.h
+++ b/include/behaviortree_cpp/decorators/skip_unless_updated.h
@@ -1,0 +1,50 @@
+/* Copyright (C) 2024 Davide Faconti -  All Rights Reserved
+*
+*   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+*   to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+*   and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+*   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+*
+*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+*   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include "behaviortree_cpp/decorator_node.h"
+
+namespace BT
+{
+
+/**
+ * @brief The SkipUnlessUpdated checks the Timestamp in an entry
+ * to determine if the value was updated since the last time (true,
+ * the first time).
+ *
+ * If it is, the child will be executed, otherwise SKIPPED is returned.
+ */
+class SkipUnlessUpdated : public DecoratorNode
+{
+public:
+  SkipUnlessUpdated(const std::string& name, const NodeConfig& config);
+
+  ~SkipUnlessUpdated() override = default;
+
+  static PortsList providedPorts()
+  {
+    return { InputPort<BT::Any>("entry", "Skip this branch unless the blackboard value "
+                                         "was updated") };
+  }
+
+private:
+  int64_t sequence_id_ = -1;
+  std::string entry_key_;
+  bool still_executing_child_ = false;
+
+  NodeStatus tick() override;
+
+  void halt() override;
+};
+
+}  // namespace BT

--- a/include/behaviortree_cpp/decorators/wait_update.h
+++ b/include/behaviortree_cpp/decorators/wait_update.h
@@ -1,0 +1,49 @@
+/* Copyright (C) 2024 Davide Faconti -  All Rights Reserved
+*
+*   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+*   to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+*   and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+*   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+*
+*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+*   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include "behaviortree_cpp/decorator_node.h"
+
+namespace BT
+{
+/**
+ * @brief The WaitValueUpdate checks the Timestamp in an entry
+ * to determine if the value was updated since the last time (true,
+ * the first time).
+ *
+ * If it is, the child will be executed, otherwise RUNNING is returned.
+ */
+class WaitValueUpdate : public DecoratorNode
+{
+public:
+  WaitValueUpdate(const std::string& name, const NodeConfig& config);
+
+  ~WaitValueUpdate() override = default;
+
+  static PortsList providedPorts()
+  {
+    return { InputPort<BT::Any>("entry", "Sleep until the entry in the blackboard is "
+                                         "updated") };
+  }
+
+private:
+  int64_t sequence_id_ = -1;
+  std::string entry_key_;
+  bool still_executing_child_ = false;
+
+  NodeStatus tick() override;
+
+  void halt() override;
+};
+
+}  // namespace BT

--- a/include/behaviortree_cpp/tree_node.h
+++ b/include/behaviortree_cpp/tree_node.h
@@ -223,6 +223,9 @@ public:
   template <typename T>
   Result getInput(const std::string& key, T& destination) const;
 
+  template <typename T>
+  ResultStamped getInputStamped(const std::string& key, T& destination) const;
+
   /** Same as bool getInput(const std::string& key, T& destination)
    * but using optional.
    *
@@ -352,6 +355,9 @@ protected:
   PreScripts& preConditionsScripts();
   PostScripts& postConditionsScripts();
 
+  template <typename T>
+  T parseString(const std::string& str) const;
+
 private:
   struct PImpl;
   std::unique_ptr<PImpl> _p;
@@ -365,32 +371,31 @@ private:
 };
 
 //-------------------------------------------------------
+
 template <typename T>
-inline Result TreeNode::getInput(const std::string& key, T& destination) const
+T TreeNode::parseString(const std::string& str) const
 {
-  // address the special case where T is an enum
-  auto ParseString = [this](const std::string& str) -> T {
-    (void)this;  // maybe unused
-    if constexpr(std::is_enum_v<T> && !std::is_same_v<T, NodeStatus>)
+  if constexpr(std::is_enum_v<T> && !std::is_same_v<T, NodeStatus>)
+  {
+    auto it = config().enums->find(str);
+    // conversion available
+    if(it != config().enums->end())
     {
-      auto it = config().enums->find(str);
-      // conversion available
-      if(it != config().enums->end())
-      {
-        return static_cast<T>(it->second);
-      }
-      else
-      {
-        // hopefully str contains a number that can be parsed. May throw
-        return static_cast<T>(convertFromString<int>(str));
-      }
+      return static_cast<T>(it->second);
     }
     else
     {
-      return convertFromString<T>(str);
+      // hopefully str contains a number that can be parsed. May throw
+      return static_cast<T>(convertFromString<int>(str));
     }
-  };
+  }
+  return convertFromString<T>(str);
+}
 
+template <typename T>
+inline ResultStamped TreeNode::getInputStamped(const std::string& key,
+                                               T& destination) const
+{
   std::string port_value_str;
 
   auto input_port_it = config().input_ports.find(key);
@@ -406,8 +411,7 @@ inline Result TreeNode::getInput(const std::string& key, T& destination) const
     {
       return nonstd::make_unexpected(StrCat("getInput() of node '", fullPath(),
                                             "' failed because the manifest doesn't "
-                                            "contain"
-                                            "the key: [",
+                                            "contain the key: [",
                                             key, "]"));
     }
     const auto& port_info = port_manifest_it->second;
@@ -416,8 +420,7 @@ inline Result TreeNode::getInput(const std::string& key, T& destination) const
     {
       return nonstd::make_unexpected(StrCat("getInput() of node '", fullPath(),
                                             "' failed because nor the manifest or the "
-                                            "XML contain"
-                                            "the key: [",
+                                            "XML contain the key: [",
                                             key, "]"));
     }
     if(port_info.defaultValue().isString())
@@ -427,27 +430,27 @@ inline Result TreeNode::getInput(const std::string& key, T& destination) const
     else
     {
       destination = port_info.defaultValue().cast<T>();
-      return {};
+      return Timestamp{};
     }
   }
 
-  auto remapped_res = getRemappedKey(key, port_value_str);
+  auto blackboard_ptr = getRemappedKey(key, port_value_str);
   try
   {
     // pure string, not a blackboard key
-    if(!remapped_res)
+    if(!blackboard_ptr)
     {
       try
       {
-        destination = ParseString(port_value_str);
+        destination = parseString<T>(port_value_str);
       }
       catch(std::exception& ex)
       {
         return nonstd::make_unexpected(StrCat("getInput(): ", ex.what()));
       }
-      return {};
+      return Timestamp{};
     }
-    const auto& remapped_key = remapped_res.value();
+    const auto& blackboard_key = blackboard_ptr.value();
 
     if(!config().blackboard)
     {
@@ -455,38 +458,51 @@ inline Result TreeNode::getInput(const std::string& key, T& destination) const
                                      "an invalid Blackboard");
     }
 
-    if(auto any_ref = config().blackboard->getAnyLocked(std::string(remapped_key)))
+    if(auto entry = config().blackboard->getEntry(std::string(blackboard_key)))
     {
-      auto val = any_ref.get();
+      std::unique_lock lk(entry->entry_mutex);
+      auto& any_value = entry->value;
+
       // support getInput<Any>()
       if constexpr(std::is_same_v<T, Any>)
       {
-        destination = *val;
+        destination = any_value;
         return {};
       }
 
-      if(!val->empty())
+      if(!entry->value.empty())
       {
-        if(!std::is_same_v<T, std::string> && val->isString())
+        if(!std::is_same_v<T, std::string> && any_value.isString())
         {
-          destination = ParseString(val->cast<std::string>());
+          destination = parseString<T>(any_value.cast<std::string>());
         }
         else
         {
-          destination = val->cast<T>();
+          destination = any_value.cast<T>();
         }
-        return {};
+        return Timestamp{ entry->sequence_id, entry->stamp };
       }
     }
 
     return nonstd::make_unexpected(StrCat("getInput() failed because it was unable to "
                                           "find the key [",
-                                          key, "] remapped to [", remapped_key, "]"));
+                                          key, "] remapped to [", blackboard_key, "]"));
   }
   catch(std::exception& err)
   {
     return nonstd::make_unexpected(err.what());
   }
+}
+
+template <typename T>
+inline Result TreeNode::getInput(const std::string& key, T& destination) const
+{
+  auto res = getInputStamped(key, destination);
+  if(!res)
+  {
+    return nonstd::make_unexpected(res.error());
+  }
+  return {};
 }
 
 template <typename T>

--- a/include/behaviortree_cpp/tree_node.h
+++ b/include/behaviortree_cpp/tree_node.h
@@ -467,7 +467,7 @@ inline ResultStamped TreeNode::getInputStamped(const std::string& key,
       if constexpr(std::is_same_v<T, Any>)
       {
         destination = any_value;
-        return {};
+        return Timestamp{ entry->sequence_id, entry->stamp };
       }
 
       if(!entry->value.empty())

--- a/src/blackboard.cpp
+++ b/src/blackboard.cpp
@@ -191,6 +191,8 @@ void Blackboard::cloneInto(Blackboard& dst) const
       dst_entry->string_converter = src_entry->string_converter;
       dst_entry->value = src_entry->value;
       dst_entry->info = src_entry->info;
+      dst_entry->sequence_id++;
+      dst_entry->stamp = std::chrono::steady_clock::now().time_since_epoch();
     }
     else
     {
@@ -295,6 +297,16 @@ void ImportBlackboardFromJSON(const nlohmann::json& json, Blackboard& blackboard
       entry->value = res->first;
     }
   }
+}
+
+Blackboard::Entry& Blackboard::Entry::operator=(const Entry& other)
+{
+  value = other.value;
+  info = other.info;
+  string_converter = other.string_converter;
+  sequence_id = other.sequence_id;
+  stamp = other.stamp;
+  return *this;
 }
 
 }  // namespace BT

--- a/src/blackboard.cpp
+++ b/src/blackboard.cpp
@@ -1,4 +1,5 @@
 #include "behaviortree_cpp/blackboard.h"
+#include <unordered_set>
 #include "behaviortree_cpp/json_export.h"
 
 namespace BT
@@ -166,15 +167,44 @@ void Blackboard::createEntry(const std::string& key, const TypeInfo& info)
 
 void Blackboard::cloneInto(Blackboard& dst) const
 {
-  std::unique_lock lk(dst.mutex_);
-  dst.storage_.clear();
+  std::unique_lock lk1(mutex_);
+  std::unique_lock lk2(dst.mutex_);
 
-  for(const auto& [key, entry] : storage_)
+  // keys that are not updated must be removed.
+  std::unordered_set<std::string> keys_to_remove;
+  auto& dst_storage = dst.storage_;
+  for(const auto& [key, _] : dst_storage)
   {
-    auto new_entry = std::make_shared<Entry>(entry->info);
-    new_entry->value = entry->value;
-    new_entry->string_converter = entry->string_converter;
-    dst.storage_.insert({ key, new_entry });
+    keys_to_remove.insert(key);
+  }
+
+  // update or create entries in dst_storage
+  for(const auto& [src_key, src_entry] : storage_)
+  {
+    keys_to_remove.erase(src_key);
+
+    auto it = dst_storage.find(src_key);
+    if(it != dst_storage.end())
+    {
+      // overwite
+      auto& dst_entry = it->second;
+      dst_entry->string_converter = src_entry->string_converter;
+      dst_entry->value = src_entry->value;
+      dst_entry->info = src_entry->info;
+    }
+    else
+    {
+      // create new
+      auto new_entry = std::make_shared<Entry>(src_entry->info);
+      new_entry->value = src_entry->value;
+      new_entry->string_converter = src_entry->string_converter;
+      dst_storage.insert({ src_key, new_entry });
+    }
+  }
+
+  for(const auto& key : keys_to_remove)
+  {
+    dst_storage.erase(key);
   }
 }
 

--- a/src/bt_factory.cpp
+++ b/src/bt_factory.cpp
@@ -697,25 +697,32 @@ std::vector<Blackboard::Ptr> BlackboardBackup(const Tree& tree)
 
 nlohmann::json ExportTreeToJSON(const Tree& tree)
 {
-  std::vector<nlohmann::json> bbs;
+  nlohmann::json out;
   for(const auto& subtree : tree.subtrees)
   {
-    bbs.push_back(ExportBlackboardToJSON(*subtree->blackboard));
+    nlohmann::json json_sub;
+    auto sub_name = subtree->instance_name;
+    if(sub_name.empty())
+    {
+      sub_name = subtree->tree_ID;
+    }
+    out[sub_name] = ExportBlackboardToJSON(*subtree->blackboard);
   }
-  return bbs;
+  return out;
 }
 
 void ImportTreeFromJSON(const nlohmann::json& json, Tree& tree)
 {
   if(json.size() != tree.subtrees.size())
   {
-    std::cerr << "Number of blackboards don't match:" << json.size() << "/"
-              << tree.subtrees.size() << "\n";
     throw std::runtime_error("Number of blackboards don't match:");
   }
-  for(size_t i = 0; i < tree.subtrees.size(); i++)
+
+  size_t index = 0;
+  for(auto& [key, array] : json.items())
   {
-    ImportBlackboardFromJSON(json.at(i), *tree.subtrees.at(i)->blackboard);
+    auto& subtree = tree.subtrees.at(index++);
+    ImportBlackboardFromJSON(array, *subtree->blackboard);
   }
 }
 

--- a/src/bt_factory.cpp
+++ b/src/bt_factory.cpp
@@ -95,6 +95,9 @@ BehaviorTreeFactory::BehaviorTreeFactory() : _p(new PImpl)
   registerNodeType<LoopNode<double>>("LoopDouble");
   registerNodeType<LoopNode<std::string>>("LoopString");
 
+  registerNodeType<SkipUnlessUpdated>("SkipUnlessUpdated");
+  registerNodeType<WaitValueUpdate>("WaitValueUpdate");
+
   for(const auto& it : _p->builders)
   {
     _p->builtin_IDs.insert(it.first);

--- a/src/decorators/skip_unless_updated.cpp
+++ b/src/decorators/skip_unless_updated.cpp
@@ -10,8 +10,6 @@
 *   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#pragma once
-
 #include "behaviortree_cpp/decorators/skip_unless_updated.h"
 
 namespace BT

--- a/src/decorators/skip_unless_updated.cpp
+++ b/src/decorators/skip_unless_updated.cpp
@@ -1,0 +1,64 @@
+/* Copyright (C) 2024 Davide Faconti -  All Rights Reserved
+*
+*   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+*   to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+*   and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+*   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+*
+*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+*   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include "behaviortree_cpp/decorators/skip_unless_updated.h"
+
+namespace BT
+{
+
+SkipUnlessUpdated::SkipUnlessUpdated(const std::string& name, const NodeConfig& config)
+  : DecoratorNode(name, config)
+{
+  const auto entry_str = config.input_ports.at("entry");
+  StringView stripped_key;
+  if(isBlackboardPointer(entry_str, &stripped_key))
+  {
+    entry_key_ = stripped_key;
+  }
+  else
+  {
+    entry_key_ = entry_str;
+  }
+}
+
+NodeStatus SkipUnlessUpdated::tick()
+{
+  // continue executing an asynchronous child
+  if(still_executing_child_)
+  {
+    auto status = child()->executeTick();
+    still_executing_child_ = (status == NodeStatus::RUNNING);
+    return status;
+  }
+
+  auto entry = config().blackboard->getEntry(entry_key_);
+  std::unique_lock lk(entry->entry_mutex);
+  auto seq = static_cast<int64_t>(entry->sequence_id);
+  if(seq == sequence_id_)
+  {
+    return NodeStatus::SKIPPED;
+  }
+  sequence_id_ = seq;
+
+  auto status = child()->executeTick();
+  still_executing_child_ = (status == NodeStatus::RUNNING);
+  return status;
+}
+
+void SkipUnlessUpdated::halt()
+{
+  still_executing_child_ = false;
+}
+
+}  // namespace BT

--- a/src/decorators/wait_update.cpp
+++ b/src/decorators/wait_update.cpp
@@ -1,0 +1,64 @@
+/* Copyright (C) 2024 Davide Faconti -  All Rights Reserved
+*
+*   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+*   to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+*   and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+*   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+*
+*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+*   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include "behaviortree_cpp/decorators/wait_update.h"
+
+namespace BT
+{
+
+WaitValueUpdate::WaitValueUpdate(const std::string& name, const NodeConfig& config)
+  : DecoratorNode(name, config)
+{
+  const auto entry_str = config.input_ports.at("entry");
+  StringView stripped_key;
+  if(isBlackboardPointer(entry_str, &stripped_key))
+  {
+    entry_key_ = stripped_key;
+  }
+  else
+  {
+    entry_key_ = entry_str;
+  }
+}
+
+NodeStatus WaitValueUpdate::tick()
+{
+  // continue executing an asynchronous child
+  if(still_executing_child_)
+  {
+    auto status = child()->executeTick();
+    still_executing_child_ = (status == NodeStatus::RUNNING);
+    return status;
+  }
+
+  auto entry = config().blackboard->getEntry(entry_key_);
+  std::unique_lock lk(entry->entry_mutex);
+  auto seq = static_cast<int64_t>(entry->sequence_id);
+  if(seq == sequence_id_)
+  {
+    return NodeStatus::RUNNING;
+  }
+  sequence_id_ = seq;
+
+  auto status = child()->executeTick();
+  still_executing_child_ = (status == NodeStatus::RUNNING);
+  return status;
+}
+
+void WaitValueUpdate::halt()
+{
+  still_executing_child_ = false;
+}
+
+}  // namespace BT


### PR DESCRIPTION
This PR introduces a new functionality: **a timestamp and unique sequence number added to each entry in the blackboard!**

Using the "blackboard" model it is hard to know if a value is "old" or was updated, since the last time it was accessed.

Now, when a blackboard entry is set, its **sequence_id** is automatically incremented and **stamp** (anoneseconds since epoch) is automatically updated.

Users can access this information using the methods:

- `Blackboard:getStamped()`
- `TreeNode::getInputStamped`

It also introduces two new **Decorators** to use this functionality:

- `WaitValueUpdate`: will sleep until a new value is set in the blackboard, and execute the child afterward.
- `SkipUnlessUpdated`: skip this entire branch, unless a value in hte blackboard is updated.

