### PR TITLE
Add library alias for BT::behaviortree_cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,8 @@ else()
     target_compile_options(${BTCPP_LIBRARY} PRIVATE -Wall -Wextra)
 endif()
 
+add_library(BT::${BTCPP_LIBRARY} ALIAS ${BTCPP_LIBRARY})
+
 #############################################################
 message( STATUS "BTCPP_LIB_DESTINATION:   ${BTCPP_LIB_DESTINATION} " )
 message( STATUS "BTCPP_INCLUDE_DESTINATION: ${BTCPP_INCLUDE_DESTINATION} " )


### PR DESCRIPTION
This pull request adds a library alias for BT::behaviortree_cpp to provide consistent usage of the BehaviorTree.CPP library in cmake.
Even though the aliased target is already exist, it cannot be used if there is someone who wants to use this library via FetchContent method.