### PR TITLE
Fixed #810 - halting of subsequent nodes in ReactiveSequence/Fallback

### DIFF
--- a/include/behaviortree_cpp_v3/controls/reactive_fallback.h
+++ b/include/behaviortree_cpp_v3/controls/reactive_fallback.h
@@ -36,8 +36,19 @@ public:
   ReactiveFallback(const std::string& name) : ControlNode(name, {})
   {}
 
+  /** A ReactiveFallback is not supposed to have more than a single
+  * anychronous node; if it does an exception is thrown.
+  * You can disabled that check, if you know what you are doing.
+  */
+  static void EnableException(bool enable);
+
 private:
-  virtual BT::NodeStatus tick() override;
+  BT::NodeStatus tick() override;
+
+  void halt() override;
+
+  int running_child_ = -1;
+  static bool throw_if_multiple_running;
 };
 
 }   // namespace BT

--- a/include/behaviortree_cpp_v3/controls/reactive_sequence.h
+++ b/include/behaviortree_cpp_v3/controls/reactive_sequence.h
@@ -36,8 +36,20 @@ public:
   ReactiveSequence(const std::string& name) : ControlNode(name, {})
   {}
 
+  /** A ReactiveSequence is not supposed to have more than a single
+  * anychronous node; if it does an exception is thrown.
+  * You can disabled that check, if you know what you are doing.
+  */
+  static void EnableException(bool enable);
+
 private:
-  virtual BT::NodeStatus tick() override;
+  BT::NodeStatus tick() override;
+
+  void halt() override;
+
+  int running_child_ = -1;
+
+  static bool throw_if_multiple_running;
 };
 
 }   // namespace BT

--- a/src/controls/reactive_fallback.cpp
+++ b/src/controls/reactive_fallback.cpp
@@ -14,9 +14,22 @@
 
 namespace BT
 {
+
+bool ReactiveFallback::throw_if_multiple_running = true;
+
+void ReactiveFallback::EnableException(bool enable)
+{
+  ReactiveFallback::throw_if_multiple_running = enable;
+}
+
 NodeStatus ReactiveFallback::tick()
 {
   size_t failure_count = 0;
+  if(status() == NodeStatus::IDLE)
+  {
+    running_child_ = -1;
+  }
+  setStatus(NodeStatus::RUNNING);
 
   for (size_t index = 0; index < childrenCount(); index++)
   {
@@ -26,12 +39,23 @@ NodeStatus ReactiveFallback::tick()
     switch (child_status)
     {
       case NodeStatus::RUNNING: {
-
-        // reset the previous children, to make sure that they are in IDLE state
-        // the next time we tick them
-        for (size_t i = 0; i < index; i++)
+        // reset the previous children, to make sure that they are
+        // in IDLE state the next time we tick them
+        for (size_t i = 0; i < childrenCount(); i++)
         {
-          haltChild(i);
+          if(i != index)
+          {
+            haltChild(i);
+          }
+        }
+        if(running_child_ == -1)
+        {
+          running_child_ = int(index);
+        }
+        else if(throw_if_multiple_running && running_child_ != int(index))
+        {
+          throw LogicError("[ReactiveFallback]: only a single child can return RUNNING.\n"
+                           "This throw can be disabled with ReactiveFallback::EnableException(false)");
         }
         return NodeStatus::RUNNING;
       }
@@ -59,6 +83,12 @@ NodeStatus ReactiveFallback::tick()
   }
 
   return NodeStatus::RUNNING;
+}
+
+void ReactiveFallback::halt()
+{
+  running_child_ = -1;
+  ControlNode::halt();
 }
 
 }   // namespace BT

--- a/src/controls/reactive_fallback.cpp
+++ b/src/controls/reactive_fallback.cpp
@@ -15,7 +15,7 @@
 namespace BT
 {
 
-bool ReactiveFallback::throw_if_multiple_running = true;
+bool ReactiveFallback::throw_if_multiple_running = false;
 
 void ReactiveFallback::EnableException(bool enable)
 {

--- a/src/controls/reactive_sequence.cpp
+++ b/src/controls/reactive_sequence.cpp
@@ -14,9 +14,22 @@
 
 namespace BT
 {
+
+bool ReactiveSequence::throw_if_multiple_running = true;
+
+void ReactiveSequence::EnableException(bool enable)
+{
+  ReactiveSequence::throw_if_multiple_running = enable;
+}
+
 NodeStatus ReactiveSequence::tick()
 {
   size_t success_count = 0;
+  if(status() == NodeStatus::IDLE)
+  {
+    running_child_ = -1;
+  }
+  setStatus(NodeStatus::RUNNING);
 
   for (size_t index = 0; index < childrenCount(); index++)
   {
@@ -26,11 +39,23 @@ NodeStatus ReactiveSequence::tick()
     switch (child_status)
     {
       case NodeStatus::RUNNING: {
-        // reset the previous children, to make sure that they are in IDLE state
-        // the next time we tick them
-        for (size_t i = 0; i < index; i++)
+        // reset the previous children, to make sure that they are
+        // in IDLE state the next time we tick them
+        for (size_t i = 0; i < childrenCount(); i++)
         {
-          haltChild(i);
+          if(i != index)
+          {
+            haltChild(i);
+          }
+        }
+        if(running_child_ == -1)
+        {
+          running_child_ = int(index);
+        }
+        else if(throw_if_multiple_running && running_child_ != int(index))
+        {
+          throw LogicError("[ReactiveSequence]: only a single child can return RUNNING.\n"
+                           "This throw can be disabled with ReactiveSequence::EnableException(false)");
         }
         return NodeStatus::RUNNING;
       }
@@ -57,6 +82,12 @@ NodeStatus ReactiveSequence::tick()
     return NodeStatus::SUCCESS;
   }
   return NodeStatus::RUNNING;
+}
+
+void ReactiveSequence::halt()
+{
+  running_child_ = -1;
+  ControlNode::halt();
 }
 
 }   // namespace BT

--- a/src/controls/reactive_sequence.cpp
+++ b/src/controls/reactive_sequence.cpp
@@ -15,7 +15,7 @@
 namespace BT
 {
 
-bool ReactiveSequence::throw_if_multiple_running = true;
+bool ReactiveSequence::throw_if_multiple_running = false;
 
 void ReactiveSequence::EnableException(bool enable)
 {


### PR DESCRIPTION
Re-added halting of subsequent nodes after a SUCCESS/FAILURE -> RUNNING state change in ReactiveSequence/Fallback by cherry-picking 53e1f15. However, changed the default not to throw exceptions if a subsequent node was RUNNING to prevent crashes of existing projects which use v3.8 and rely on this capability of ReactiveSequence/Fallback (can be reverted if you want so...)

<!--
You must run clang-format, otherwise your change may not pass the tests on CI
We recommend using pre-commit.

To use:
    pre-commit run -a
Or:
     pre-commit install  # (runs every time you commit in git)

See https://github.com/pre-commit/pre-commit
-->
