### PR TITLE
Backport of some build-related flatbuffers changes

### DIFF
--- a/include/behaviortree_cpp_v3/flatbuffers/base.h
+++ b/include/behaviortree_cpp_v3/flatbuffers/base.h
@@ -237,12 +237,17 @@ namespace flatbuffers {
       }
       #define FLATBUFFERS_HAS_STRING_VIEW 1
     // Check for absl::string_view
-    #elif __has_include("absl/strings/string_view.h")
-      #include "absl/strings/string_view.h"
-      namespace flatbuffers {
-        typedef absl::string_view string_view;
-      }
-      #define FLATBUFFERS_HAS_STRING_VIEW 1
+    #elif __has_include("absl/strings/string_view.h") && \
+          __has_include("absl/base/config.h") && \
+          (__cplusplus >= 201411)
+      #include "absl/base/config.h"
+      #if !defined(ABSL_USES_STD_STRING_VIEW)
+        #include "absl/strings/string_view.h"
+        namespace flatbuffers {
+          typedef absl::string_view string_view;
+        }
+        #define FLATBUFFERS_HAS_STRING_VIEW 1
+      #endif
     #endif
   #endif // __has_include
 #endif // !FLATBUFFERS_HAS_STRING_VIEW

--- a/include/behaviortree_cpp_v3/flatbuffers/stl_emulation.h
+++ b/include/behaviortree_cpp_v3/flatbuffers/stl_emulation.h
@@ -625,7 +625,7 @@ class span FLATBUFFERS_FINAL_CLASS {
  private:
   // This is a naive implementation with 'count_' member even if (Extent != dynamic_extent).
   pointer const data_;
-  const size_type count_;
+  size_type count_;
 };
 
  #if !defined(FLATBUFFERS_SPAN_MINIMAL)


### PR DESCRIPTION
<!--
You must run clang-format, otherwise your change may not pass the tests on CI
We recommend using pre-commit.

To use:
    pre-commit run -a
Or:
     pre-commit install  # (runs every time you commit in git)

See https://github.com/pre-commit/pre-commit
-->

Related to #818.

This also fixes an issue when having abseil preinstalled and compiled with ``std::string_view`` support. This issue was fixed on upstream flatbuffers already some time ago. 

