### PR TITLE
Add in call to ament_export_targets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,7 @@ if(ament_cmake_FOUND)
 
     ament_export_include_directories(include)
     ament_export_libraries(${BEHAVIOR_TREE_LIBRARY})
+    ament_export_targets(${BEHAVIOR_TREE_LIBRARY}Targets)
     ament_package()
 elseif(catkin_FOUND)
 


### PR DESCRIPTION
That way downstream ament packages can use this
package as a CMake target.

I'll note that I targeted this PR to the v3.8 branch, as that is what I'm compiling against for Navigation2 on Iron right now.  But I'm happy to target to another branch, depending on best development practices for this repository.