### PR TITLE
Initialize template variable `T out` in getInput

### DIFF
--- a/include/behaviortree_cpp/tree_node.h
+++ b/include/behaviortree_cpp/tree_node.h
@@ -256,7 +256,7 @@ public:
   template <typename T>
   [[nodiscard]] Expected<T> getInput(const std::string& key) const
   {
-    T out;
+    T out{};
     auto res = getInput(key, out);
     return (res) ? Expected<T>(out) : nonstd::make_unexpected(res.error());
   }


### PR DESCRIPTION
<!--
You must run clang-format, otherwise your change may not pass the tests on CI
We recommend using pre-commit.

To use:
    pre-commit run -a
Or:
     pre-commit install  # (runs every time you commit in git)

See https://github.com/pre-commit/pre-commit
-->

Calling `Expected<T> getInput(const std::string& key)` with a primitive T type leads to clang-tidy complaining about `out` being undefined. This change initializes `out` and should work with both primitive and class T types.