### PR TITLE
fixed: support utf-8 path xml-file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,8 @@ else()
     include(cmake/conan_build.cmake)
 endif()
 
+add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
+add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 
 #############################################################
 # LIBRARY

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,9 +74,6 @@ else()
     include(cmake/conan_build.cmake)
 endif()
 
-add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
-add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
-
 #############################################################
 # LIBRARY
 
@@ -189,6 +186,7 @@ target_compile_definitions(${BTCPP_LIBRARY} PUBLIC BTCPP_LIBRARY_VERSION="${CMAK
 target_compile_features(${BTCPP_LIBRARY} PUBLIC cxx_std_17)
 
 if(MSVC)
+	target_compile_options(${BTCPP_LIBRARY} PRIVATE "/source-charset:utf-8")
 else()
     target_compile_options(${BTCPP_LIBRARY} PRIVATE -Wall -Wextra)
 endif()

--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -19,6 +19,12 @@
 #include <string>
 #include <typeindex>
 
+#if defined(_MSVC_LANG) && !defined(__clang__)
+#define __bt_cplusplus (_MSC_VER == 1900 ? 201103L : _MSVC_LANG)
+#else
+#define __bt_cplusplus __cplusplus
+#endif
+
 #if defined(__linux) || defined(__linux__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wattributes"
@@ -254,7 +260,12 @@ void XMLParser::PImpl::loadDocImpl(XMLDocument* doc, bool add_includes)
       break;
     }
 
-    std::filesystem::path file_path(incl_node->Attribute("path"));
+#if __bt_cplusplus >= 202002L
+    auto file_path(std::filesystem::path(incl_node->Attribute("path")));
+#else
+    auto file_path(std::filesystem::u8path(incl_node->Attribute("path")));
+#endif
+
     const char* ros_pkg_relative_path = incl_node->Attribute("ros_pkg");
 
     if(ros_pkg_relative_path)


### PR DESCRIPTION

<!--
You must run clang-format, otherwise your change may not pass the tests on CI
We recommend using pre-commit.

To use:
    pre-commit run -a
Or:
     pre-commit install  # (runs every time you commit in git)

See https://github.com/pre-commit/pre-commit
-->

1. added compile version check to support Chinese path xml-file parsing 
3. cmake add msvc /utf-8 options