### PR TITLE
Allow letting value field empty for numeric ports

### DIFF
--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -659,7 +659,7 @@ TreeNode::Ptr XMLParser::PImpl::createNodeFromXML(const XMLElement* element,
                                     "] is found in the XML, but not in the "
                                     "providedPorts()"));
         }
-        else
+        else if(!port_value.empty())
         {
           const auto& port_model = port_model_it->second;
           bool is_blacbkboard = port_value.size() >= 3 && port_value.front() == '{' &&


### PR DESCRIPTION
Unlike on v3, on v4 you cannot let the value field empty for numeric ports. You get this parsing error:
```
The port with name "angle_tolerance" and value "" can not be converted to double
```
I think v3 behavior was nicer cause it gives you a clean way to make your numeric fields optional:
empty string -> null_optional value -> use your default

On v4 you need to provide a value that you know is a default (e.g. nan), but nobody else will know. This is awkward and different from string values, where empty string is allowed.

Disclaimer: I didn't dig deep into the code, so not sure that this is the best implementation. It just replicate v3 behavior.