### PR TITLE
Support vector<Any> -> vector<typename T::value_type> conversion

### DIFF
--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -786,8 +786,10 @@ TreeNode::Ptr XMLParser::PImpl::createNodeFromXML(const XMLElement* element,
 
           // special case related to convertFromString
           bool const string_input = (prev_info->type() == typeid(std::string));
+          // special case related to unwrapping vector<Any> objects.
+          bool const vec_any_input = (prev_info->type() == typeid(std::vector<Any>));
 
-          if(port_type_mismatch && !string_input)
+          if(port_type_mismatch && !string_input && !vec_any_input)
           {
             blackboard->debugMessage();
 


### PR DESCRIPTION
Don't check port type alignment for vector<Any>

<!--
You must run clang-format, otherwise your change may not pass the tests on CI
We recommend using pre-commit.

To use:
    pre-commit run -a
Or:
     pre-commit install  # (runs every time you commit in git)

See https://github.com/pre-commit/pre-commit
-->
