### PR TITLE
Put minitrace in the build_interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,7 @@ target_link_libraries(${BTCPP_LIBRARY}
         Threads::Threads
         ${CMAKE_DL_LIBS}
         $<BUILD_INTERFACE:foonathan::lexy>
-        minitrace
+        $<BUILD_INTERFACE:minitrace>
     PUBLIC
         ${BTCPP_EXTRA_LIBRARIES}
 )


### PR DESCRIPTION
Building behavior tree with standard cmake (no ament, no conan etc) will result in:

```
CMake Error: install(EXPORT "behaviortree_cppTargets" ...) includes target "behaviortree_cpp" which requires target "minitrace" that is not in any export set.
```
By putting the `minitrace` library link in the build_interface, it allows to pass the configuration and get the final Config.cmake and Targets.cmake

Before:
![image](https://github.com/user-attachments/assets/1940db16-50bc-40ac-9b3b-626382689602)
After:
![Screenshot 2024-09-27 081358](https://github.com/user-attachments/assets/650a54ee-3268-47bd-8e03-20537c7954ed)


