### PR TITLE
use relative path in .Doxyfile

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = /home/davide.faconti/ws_behavior_tree/src/Behavior-Tree/doc
+OUTPUT_DIRECTORY       = ./doc
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -781,7 +781,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = /home/davide.faconti/ws_behavior_tree/src/Behavior-Tree/include
+INPUT                  = ./include
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -863,8 +863,8 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = /home/davide.faconti/ws_behavior_tree/src/Behavior-Tree/3rdparty \
-                         /home/davide.faconti/ws_behavior_tree/src/Behavior-Tree/gtest
+EXCLUDE                = ./3rdparty \
+                         ./gtest
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded


### PR DESCRIPTION
This micro PR removes refercences to @facontidavide local environment from the `.Doxyfile` by favoring relative path usage.