### PR TITLE
Allow BT::AnyTypeAllowed as port type and setOuput using BT::Any

### DIFF
--- a/include/behaviortree_cpp/tree_node.h
+++ b/include/behaviortree_cpp/tree_node.h
@@ -585,10 +585,12 @@ inline Result TreeNode::setOutput(const std::string& key, const T& value)
 
   if constexpr(std::is_same_v<BT::Any, T>)
   {
-    if(config().manifest->ports.at(key).type() != typeid(BT::Any))
+    const std::type_index type = config().manifest->ports.at(key).type();
+    if(type != typeid(BT::Any) && type != typeid(BT::AnyTypeAllowed))
     {
-      throw LogicError("setOutput<Any> is not allowed, unless the port "
-                       "was declared using OutputPort<Any>");
+      throw LogicError("setOutput<BT::Any> is not allowed, unless the port "
+                       "was declared using OutputPort<BT::Any> or "
+                       "OutputPort<BT::AnyTypeAllowed>");
     }
   }
 


### PR DESCRIPTION
This pull request enables to use `BT::AnyTypeAllowed` when specifying the type of a port, basically meaning that this port has no static type and the node will determine the type of the variable dynamically.

See #893 
