### PR TITLE
Fix script compare with negative number exception

### DIFF
--- a/examples/t09_scripting.cpp
+++ b/examples/t09_scripting.cpp
@@ -10,7 +10,7 @@ static const char* xml_text = R"(
         <Sequence>
             <Script code=" msg:='hello world' " />
             <Script code=" A:=THE_ANSWER; B:=3.14; color:=RED " />
-            <Precondition if="A>B && color != BLUE" else="FAILURE">
+            <Precondition if="A>-B && color != BLUE" else="FAILURE">
                 <Sequence>
                   <SaySomething message="{A}"/>
                   <SaySomething message="{B}"/>

--- a/include/behaviortree_cpp/scripting/operators.hpp
+++ b/include/behaviortree_cpp/scripting/operators.hpp
@@ -796,9 +796,9 @@ struct Expression : lexy::expression_production
                                dsl::op<Ast::ExprComparison::greater_equal>(LEXY_LIT(">"
                                                                                     "="));
 
-    // The use of dsl::groups ensures that an expression can either contain math or bit
+    // The use of dsl::groups ensures that an expression can either contain math or bit or string
     // operators. Mixing requires parenthesis.
-    using operand = dsl::groups<math_sum, bit_or>;
+    using operand = dsl::groups<math_sum, bit_or, string_concat>;
   };
 
   // Logical operators,  || and &&
@@ -808,7 +808,7 @@ struct Expression : lexy::expression_production
         dsl::op<Ast::ExprBinaryArithmetic::logic_or>(LEXY_LIT("||")) /
         dsl::op<Ast::ExprBinaryArithmetic::logic_and>(LEXY_LIT("&&"));
 
-    using operand = dsl::groups<string_concat, comparison>;
+    using operand = comparison;
   };
 
   // x ? y : z


### PR DESCRIPTION
# Fix issue:
#832

# Analysis:
In the example of nested groups in Lexy, the matching behavior is somewhat strange. Therefore, it is recommended to temporarily avoid using nested groups.
https://github.com/foonathan/lexy/issues/219

# Solution:
Remove nested groups and move `string_concat` into comparison operations. This actually aligns better with intuition, since theoretically it should be possible to perform `comparison` operations between two `string_concat `operations.

# References:
https://github.com/foonathan/lexy/blob/77ba5fa5a62f16b3ab5440c6d6ef42a7cdd176bb/tests/lexy/dsl/expression.cpp#L1193-L1196
https://lexy.foonathan.net/reference/dsl/expression/#groups