### PR TITLE
[retry_node] Refresh max_attempts_ in case it changed in one of the child nodes

### DIFF
--- a/src/decorators/retry_node.cpp
+++ b/src/decorators/retry_node.cpp
@@ -67,6 +67,8 @@ NodeStatus RetryNode::tick()
 
       case NodeStatus::FAILURE: {
         try_count_++;
+        // Refresh max_attempts_ in case it changed in one of the child nodes
+        getInput(NUM_ATTEMPTS, max_attempts_);
         do_loop = try_count_ < max_attempts_ || max_attempts_ == -1;
 
         resetChild();


### PR DESCRIPTION
This PR modifies the `retry_node` "RetryUntilSuccessful" to refresh its variable `max_attempts_` from its port inside the while loop.
This is need in order to not be out of sync with the blackboard variable in case it has been modified by one of the child of the retry_node node.
