### PR TITLE
Fix ROS 2 build when ZeroMQ or SQlite3 include are not in the default include path

### DIFF
--- a/cmake/ament_build.cmake
+++ b/cmake/ament_build.cmake
@@ -10,7 +10,10 @@ if(BTCPP_SQLITE_LOGGING)
     find_package(SQLite3 REQUIRED)
 endif()
 
-find_package(ament_index_cpp REQUIRED)
+find_package(ament_index_cpp REQUIRED
+
+set(BTCPP_EXTRA_INCLUDE_DIRS ${ZeroMQ_INCLUDE_DIRS}
+                             ${SQLite3_INCLUDE_DIRS})
 
 set( BTCPP_EXTRA_LIBRARIES
     $<BUILD_INTERFACE:ament_index_cpp::ament_index_cpp>
@@ -26,6 +29,7 @@ set( BTCPP_BIN_DESTINATION     bin )
 
 mark_as_advanced(
     BTCPP_EXTRA_LIBRARIES
+    BTCPP_EXTRA_INCLUDE_DIRS
     BTCPP_LIB_DESTINATION
     BTCPP_INCLUDE_DESTINATION
     BTCPP_BIN_DESTINATION )

--- a/cmake/ament_build.cmake
+++ b/cmake/ament_build.cmake
@@ -10,7 +10,7 @@ if(BTCPP_SQLITE_LOGGING)
     find_package(SQLite3 REQUIRED)
 endif()
 
-find_package(ament_index_cpp REQUIRED
+find_package(ament_index_cpp REQUIRED)
 
 set(BTCPP_EXTRA_INCLUDE_DIRS ${ZeroMQ_INCLUDE_DIRS}
                              ${SQLite3_INCLUDE_DIRS})


### PR DESCRIPTION
If `ZeroMQ` or `SQlite3` includes are not found in the default include path of the used compilers, without this fix the build will fail.