### PR TITLE
Fix clang test failures from Any.cast

### DIFF
--- a/include/behaviortree_cpp/utils/convert_impl.hpp
+++ b/include/behaviortree_cpp/utils/convert_impl.hpp
@@ -89,41 +89,24 @@ inline void checkLowerLimit(const From& from)
 template <typename From, typename To>
 inline void checkTruncation(const From& from)
 {
-  // Handle integer to floating point
-  if constexpr(std::is_integral_v<From> && std::is_floating_point_v<To>)
-  {
-    // Check if value can be represented exactly in the target type
-    To as_float = static_cast<To>(from);
-    From back_conv = static_cast<From>(as_float);
-    if(back_conv != from)
-    {
-      throw std::runtime_error("Loss of precision in conversion to floating point");
-    }
-  }
   // Handle floating point to integer
   if constexpr(std::is_floating_point_v<From> && std::is_integral_v<To>)
   {
-    if(from > static_cast<From>(std::numeric_limits<To>::max()) ||
-       from < static_cast<From>(std::numeric_limits<To>::lowest()) ||
-       from != std::nearbyint(from))
+    if(from != std::nearbyint(from))
     {
       throw std::runtime_error("Invalid floating point to integer conversion");
     }
   }
-  // Handle other conversions
-  else
+
+  To as_target = static_cast<To>(from);
+  From back_to_source = static_cast<From>(as_target);
+  if(from != back_to_source)
   {
-    if(from > static_cast<From>(std::numeric_limits<To>::max()) ||
-       from < static_cast<From>(std::numeric_limits<To>::lowest()))
+    if constexpr(std::is_integral_v<From> && std::is_floating_point_v<To>)
     {
-      throw std::runtime_error("Value outside numeric limits");
+      throw std::runtime_error("Loss of precision in conversion to floating point");
     }
-    To as_target = static_cast<To>(from);
-    From back_to_source = static_cast<From>(as_target);
-    if(from != back_to_source)
-    {
-      throw std::runtime_error("Value truncated in conversion");
-    }
+    throw std::runtime_error("Value truncated in conversion");
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/BehaviorTree/BehaviorTree.CPP/issues/939
Only results in one less detailed error message (but otherwise the same failure conditions are still covered) and fixes the clang build.

To test build in clang and run unit tests. They should now pass.

```
CC=clang CXX=clang++ colcon build
./build/behaviortree_cpp/tests/behaviortree_cpp_test
```