### PR TITLE
Failing test with std::vector

### DIFF
--- a/tests/gtest_json.cpp
+++ b/tests/gtest_json.cpp
@@ -80,6 +80,7 @@ protected:
   {
     BT::JsonExporter& exporter = BT::JsonExporter::get();
     exporter.addConverter<TestTypes::Pose3D>();
+    exporter.addConverter<std::vector<TestTypes::Pose3D>>();
     exporter.addConverter<TestTypes::Vector3D>();
     exporter.addConverter<TestTypes::Quaternion3D>();
 
@@ -194,4 +195,65 @@ TEST_F(JsonTest, BlackboardInOut)
   ASSERT_EQ(vect_out.x, 1.1);
   ASSERT_EQ(vect_out.y, 2.2);
   ASSERT_EQ(vect_out.z, 3.3);
+}
+
+TEST_F(JsonTest, VectorOfCustomTypes)
+{
+  BT::JsonExporter& exporter = BT::JsonExporter::get();
+
+  std::vector<TestTypes::Pose3D> poses(2);
+  poses[0].pos.x = 1;
+  poses[0].pos.y = 2;
+  poses[0].pos.z = 3;
+  poses[0].rot.w = 4;
+  poses[0].rot.x = 5;
+  poses[0].rot.y = 6;
+  poses[0].rot.z = 7;
+  poses[1].pos.x = 8;
+  poses[1].pos.y = 9;
+  poses[1].pos.z = 10;
+  poses[1].rot.w = 11;
+  poses[1].rot.x = 12;
+  poses[1].rot.y = 13;
+  poses[1].rot.z = 14;
+
+  nlohmann::json json;
+  exporter.toJson(BT::Any(poses), json["poses"]);
+
+  std::cout << json.dump(2) << std::endl;
+
+  ASSERT_EQ(json["poses"][0]["__type"], "Pose3D");
+  ASSERT_EQ(json["poses"][0]["pos"]["x"], 1);
+  ASSERT_EQ(json["poses"][0]["pos"]["y"], 2);
+  ASSERT_EQ(json["poses"][0]["pos"]["z"], 3);
+  ASSERT_EQ(json["poses"][0]["rot"]["w"], 4);
+  ASSERT_EQ(json["poses"][0]["rot"]["x"], 5);
+  ASSERT_EQ(json["poses"][0]["rot"]["y"], 6);
+  ASSERT_EQ(json["poses"][0]["rot"]["z"], 7);
+  ASSERT_EQ(json["poses"][1]["__type"], "Pose3D");
+  ASSERT_EQ(json["poses"][1]["pos"]["x"], 8);
+  ASSERT_EQ(json["poses"][1]["pos"]["y"], 9);
+  ASSERT_EQ(json["poses"][1]["pos"]["z"], 10);
+  ASSERT_EQ(json["poses"][1]["rot"]["w"], 11);
+  ASSERT_EQ(json["poses"][1]["rot"]["x"], 12);
+  ASSERT_EQ(json["poses"][1]["rot"]["y"], 13);
+  ASSERT_EQ(json["poses"][1]["rot"]["z"], 14);
+
+  // check the two-ways transform, i.e. "from_json"
+  auto poses2 = exporter.fromJson(json["poses"])->first.cast<std::vector<TestTypes::Pose3D>>();
+  ASSERT_EQ(poses.size(), poses2.size());
+  ASSERT_EQ(poses[0].pos.x, poses2[0].pos.x);
+  ASSERT_EQ(poses[0].pos.y, poses2[0].pos.y);
+  ASSERT_EQ(poses[0].pos.z, poses2[0].pos.z);
+  ASSERT_EQ(poses[0].rot.w, poses2[0].rot.w);
+  ASSERT_EQ(poses[0].rot.x, poses2[0].rot.x);
+  ASSERT_EQ(poses[0].rot.y, poses2[0].rot.y);
+  ASSERT_EQ(poses[0].rot.z, poses2[0].rot.z);
+  ASSERT_EQ(poses[1].pos.x, poses2[1].pos.x);
+  ASSERT_EQ(poses[1].pos.y, poses2[1].pos.y);
+  ASSERT_EQ(poses[1].pos.z, poses2[1].pos.z);
+  ASSERT_EQ(poses[1].rot.w, poses2[1].rot.w);
+  ASSERT_EQ(poses[1].rot.x, poses2[1].rot.x);
+  ASSERT_EQ(poses[1].rot.y, poses2[1].rot.y);
+  ASSERT_EQ(poses[1].rot.z, poses2[1].rot.z);
 }

--- a/tests/gtest_json.cpp
+++ b/tests/gtest_json.cpp
@@ -57,12 +57,12 @@ BT_JSON_CONVERTER(Pose3D, v)
 }
 
 // specialized functions
-void jsonFromTime(const Time & t, nlohmann::json & j)
+void jsonFromTime(const Time& t, nlohmann::json& j)
 {
   j["stamp"] = double(t.sec) + 1e-9 * double(t.nsec);
 }
 
-void jsonToTime(const nlohmann::json & j, Time & t)
+void jsonToTime(const nlohmann::json& j, Time& t)
 {
   double sec = j["stamp"];
   t.sec = int(sec);
@@ -78,7 +78,7 @@ class JsonTest : public testing::Test
 protected:
   JsonTest()
   {
-    BT::JsonExporter & exporter = BT::JsonExporter::get();
+    BT::JsonExporter& exporter = BT::JsonExporter::get();
     exporter.addConverter<TestTypes::Pose3D>();
     exporter.addConverter<std::vector<TestTypes::Pose3D>>();
     exporter.addConverter<TestTypes::Vector3D>();
@@ -91,9 +91,9 @@ protected:
 
 TEST_F(JsonTest, TwoWaysConversion)
 {
-  BT::JsonExporter & exporter = BT::JsonExporter::get();
+  BT::JsonExporter& exporter = BT::JsonExporter::get();
 
-  TestTypes::Pose3D pose = {{1, 2, 3}, {4, 5, 6, 7}};
+  TestTypes::Pose3D pose = { { 1, 2, 3 }, { 4, 5, 6, 7 } };
 
   nlohmann::json json;
   exporter.toJson(BT::Any(69), json["int"]);
@@ -135,9 +135,9 @@ TEST_F(JsonTest, TwoWaysConversion)
 
 TEST_F(JsonTest, CustomTime)
 {
-  BT::JsonExporter & exporter = BT::JsonExporter::get();
+  BT::JsonExporter& exporter = BT::JsonExporter::get();
 
-  TestTypes::Time stamp = {3, 8000000};
+  TestTypes::Time stamp = { 3, 8000000 };
   nlohmann::json json;
   exporter.toJson(BT::Any(stamp), json);
   std::cout << json.dump() << std::endl;
@@ -180,7 +180,7 @@ TEST_F(JsonTest, BlackboardInOut)
   auto bb_in = BT::Blackboard::create();
   bb_in->set("int", 42);
   bb_in->set("real", 3.14);
-  bb_in->set("vect", TestTypes::Vector3D{1.1, 2.2, 3.3});
+  bb_in->set("vect", TestTypes::Vector3D{ 1.1, 2.2, 3.3 });
 
   auto json = ExportBlackboardToJSON(*bb_in);
   std::cout << json.dump(2) << std::endl;
@@ -199,7 +199,7 @@ TEST_F(JsonTest, BlackboardInOut)
 
 TEST_F(JsonTest, VectorOfCustomTypes)
 {
-  BT::JsonExporter & exporter = BT::JsonExporter::get();
+  BT::JsonExporter& exporter = BT::JsonExporter::get();
 
   std::vector<TestTypes::Pose3D> poses(2);
   poses[0].pos.x = 1;
@@ -241,7 +241,7 @@ TEST_F(JsonTest, VectorOfCustomTypes)
 
   // check the two-ways transform, i.e. "from_json"
   auto poses2 =
-    exporter.fromJson(json["poses"])->first.cast<std::vector<TestTypes::Pose3D>>();
+      exporter.fromJson(json["poses"])->first.cast<std::vector<TestTypes::Pose3D>>();
   ASSERT_EQ(poses.size(), poses2.size());
   ASSERT_EQ(poses[0].pos.x, poses2[0].pos.x);
   ASSERT_EQ(poses[0].pos.y, poses2[0].pos.y);

--- a/tests/gtest_json.cpp
+++ b/tests/gtest_json.cpp
@@ -57,12 +57,12 @@ BT_JSON_CONVERTER(Pose3D, v)
 }
 
 // specialized functions
-void jsonFromTime(const Time& t, nlohmann::json& j)
+void jsonFromTime(const Time & t, nlohmann::json & j)
 {
   j["stamp"] = double(t.sec) + 1e-9 * double(t.nsec);
 }
 
-void jsonToTime(const nlohmann::json& j, Time& t)
+void jsonToTime(const nlohmann::json & j, Time & t)
 {
   double sec = j["stamp"];
   t.sec = int(sec);
@@ -78,7 +78,7 @@ class JsonTest : public testing::Test
 protected:
   JsonTest()
   {
-    BT::JsonExporter& exporter = BT::JsonExporter::get();
+    BT::JsonExporter & exporter = BT::JsonExporter::get();
     exporter.addConverter<TestTypes::Pose3D>();
     exporter.addConverter<std::vector<TestTypes::Pose3D>>();
     exporter.addConverter<TestTypes::Vector3D>();
@@ -91,9 +91,9 @@ protected:
 
 TEST_F(JsonTest, TwoWaysConversion)
 {
-  BT::JsonExporter& exporter = BT::JsonExporter::get();
+  BT::JsonExporter & exporter = BT::JsonExporter::get();
 
-  TestTypes::Pose3D pose = { { 1, 2, 3 }, { 4, 5, 6, 7 } };
+  TestTypes::Pose3D pose = {{1, 2, 3}, {4, 5, 6, 7}};
 
   nlohmann::json json;
   exporter.toJson(BT::Any(69), json["int"]);
@@ -135,9 +135,9 @@ TEST_F(JsonTest, TwoWaysConversion)
 
 TEST_F(JsonTest, CustomTime)
 {
-  BT::JsonExporter& exporter = BT::JsonExporter::get();
+  BT::JsonExporter & exporter = BT::JsonExporter::get();
 
-  TestTypes::Time stamp = { 3, 8000000 };
+  TestTypes::Time stamp = {3, 8000000};
   nlohmann::json json;
   exporter.toJson(BT::Any(stamp), json);
   std::cout << json.dump() << std::endl;
@@ -180,7 +180,7 @@ TEST_F(JsonTest, BlackboardInOut)
   auto bb_in = BT::Blackboard::create();
   bb_in->set("int", 42);
   bb_in->set("real", 3.14);
-  bb_in->set("vect", TestTypes::Vector3D{ 1.1, 2.2, 3.3 });
+  bb_in->set("vect", TestTypes::Vector3D{1.1, 2.2, 3.3});
 
   auto json = ExportBlackboardToJSON(*bb_in);
   std::cout << json.dump(2) << std::endl;
@@ -199,7 +199,7 @@ TEST_F(JsonTest, BlackboardInOut)
 
 TEST_F(JsonTest, VectorOfCustomTypes)
 {
-  BT::JsonExporter& exporter = BT::JsonExporter::get();
+  BT::JsonExporter & exporter = BT::JsonExporter::get();
 
   std::vector<TestTypes::Pose3D> poses(2);
   poses[0].pos.x = 1;
@@ -240,7 +240,8 @@ TEST_F(JsonTest, VectorOfCustomTypes)
   ASSERT_EQ(json["poses"][1]["rot"]["z"], 14);
 
   // check the two-ways transform, i.e. "from_json"
-  auto poses2 = exporter.fromJson(json["poses"])->first.cast<std::vector<TestTypes::Pose3D>>();
+  auto poses2 =
+    exporter.fromJson(json["poses"])->first.cast<std::vector<TestTypes::Pose3D>>();
   ASSERT_EQ(poses.size(), poses2.size());
   ASSERT_EQ(poses[0].pos.x, poses2[0].pos.x);
   ASSERT_EQ(poses[0].pos.y, poses2[0].pos.y);


### PR DESCRIPTION
I am opening this PR as you mentioned in [Nav2#4957](https://github.com/ros-navigation/navigation2/issues/4957).

I have added a failing test for JSON conversions of std::vector. The test fails in this line:

```cpp
auto poses2 = exporter.fromJson(json["poses"])->first.cast<std::vector<TestTypes::Pose3D>>();
```
with this error
```
nonstd::expected_lite::expected<T, E>::value_type* nonstd::expected_lite::expected<T, E>::operator->() [with T = std::pair<BT::Any, BT::TypeInfo>; E = std::__cxx11::basic_string<char>; value_type = std::pair<BT::Any, BT::TypeInfo>]: Assertion `has_value()' failed.
```

I'm not entirely sure but, this may be related to [Groot2#55](https://github.com/BehaviorTree/Groot2/issues/55)