### PR TITLE
Fix regression by adding missing dependencies: gtest_vendor and ament…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ option(ENABLE_FUZZING "Enable fuzzing builds" OFF)
 option(USE_AFLPLUSPLUS "Use AFL++ instead of libFuzzer" OFF)
 option(ENABLE_DEBUG "Enable debug build with full symbols" OFF)
 option(FORCE_STATIC_LINKING "Force static linking of all dependencies" OFF)
+find_package(ament_cmake REQUIRED)
+find_package(gtest_vendor REQUIRED)
 
 set(BASE_FLAGS "")
 

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,12 @@
   <author>Davide Faconti</author>
 
   <build_depend>ros_environment</build_depend>
+  <build_depend>ament_cmake</build_depend>
+  <build_depend>gtest_vendor</build_depend>
+
+  <exec_depend>ament_cmake</exec_depend>
+  <exec_depend>gtest_vendor</exec_depend>
+
 
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
   <depend condition="$ROS_VERSION == 1">roslib</depend>


### PR DESCRIPTION
…_cmake_ros

<!--
You must run clang-format, otherwise your change may not pass the tests on CI
We recommend using pre-commit.

To use:
    pre-commit run -a
Or:
     pre-commit install  # (runs every time you commit in git)

See https://github.com/pre-commit/pre-commit
-->
