### PR TITLE
Rolling regression fix (for real this time)

### DIFF
--- a/.github/workflows/cmake_ubuntu.yml
+++ b/.github/workflows/cmake_ubuntu.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
 
     steps:
     - uses: actions/checkout@v2
@@ -49,7 +49,7 @@ jobs:
     - name: Build
       shell: bash
       working-directory: ${{github.workspace}}/build
-      run: cmake --build . --config ${{env.BUILD_TYPE}}
+      run: cmake --build . --config ${{env.BUILD_TYPE}} -DBUILD_TESTING=ON
 
     - name: run test (Linux)
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/cmake_ubuntu.yml
+++ b/.github/workflows/cmake_ubuntu.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04]
+        os: [ubuntu-22.04]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cmake_ubuntu.yml
+++ b/.github/workflows/cmake_ubuntu.yml
@@ -44,12 +44,12 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{github.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DBUILD_TESTING=ON
 
     - name: Build
       shell: bash
       working-directory: ${{github.workspace}}/build
-      run: cmake --build . --config ${{env.BUILD_TYPE}} -DBUILD_TESTING=ON
+      run: cmake --build . --config ${{env.BUILD_TYPE}}
 
     - name: run test (Linux)
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/cmake_windows.yml
+++ b/.github/workflows/cmake_windows.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Build
       working-directory: ${{github.workspace}}/build
       shell: bash
-      run: cmake --build . --config ${{env.BUILD_TYPE}}
+      run: cmake --build . --config ${{env.BUILD_TYPE}} -DBUILD_TESTING=ON
 
     - name: run test (Windows)
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/cmake_windows.yml
+++ b/.github/workflows/cmake_windows.yml
@@ -39,12 +39,12 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{github.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DBUILD_TESTING=ON
 
     - name: Build
       working-directory: ${{github.workspace}}/build
       shell: bash
-      run: cmake --build . --config ${{env.BUILD_TYPE}} -DBUILD_TESTING=ON
+      run: cmake --build . --config ${{env.BUILD_TYPE}}
 
     - name: run test (Windows)
       working-directory: ${{github.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,7 @@ endif()
 
 ######################################################
 
+include(CTest)
 if (BTCPP_UNIT_TESTS AND BUILD_TESTING)
     add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,7 +237,7 @@ endif()
 
 ######################################################
 
-if (BTCPP_UNIT_TESTS)
+if (BTCPP_UNIT_TESTS AND BUILD_TESTING)
     add_subdirectory(tests)
 endif()
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -13,7 +13,7 @@ test = "PATH=\"$PATH;build/Release\" build/tests/Release/behaviortree_cpp_test.e
 test = "./build/tests/behaviortree_cpp_test"
 
 [tasks]
-build = "mkdir -p build && cd build && cmake ../ -DCMAKE_BUILD_TYPE=Release && cmake --build . --parallel --config Release --DBUILD_TESTING=ON"
+build = "mkdir -p build && cd build && cmake ../ -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON && cmake --build . --parallel --config Release"
 
 [dependencies]
 cmake = ">=3.16.3"

--- a/pixi.toml
+++ b/pixi.toml
@@ -13,7 +13,7 @@ test = "PATH=\"$PATH;build/Release\" build/tests/Release/behaviortree_cpp_test.e
 test = "./build/tests/behaviortree_cpp_test"
 
 [tasks]
-build = "mkdir -p build && cd build && cmake ../ -DCMAKE_BUILD_TYPE=Release && cmake --build . --parallel --config Release"
+build = "mkdir -p build && cd build && cmake ../ -DCMAKE_BUILD_TYPE=Release && cmake --build . --parallel --config Release --DBUILD_TESTING=ON"
 
 [dependencies]
 cmake = ">=3.16.3"


### PR DESCRIPTION
<!--
You must run clang-format, otherwise your change may not pass the tests on CI
We recommend using pre-commit.

To use:
    pre-commit run -a
Or:
     pre-commit install  # (runs every time you commit in git)

See https://github.com/pre-commit/pre-commit
-->

Try number 2, this time `BUILD_TESTING` should actually be respected.  Also updated CI so that it still works.