### PR TITLE
Fix dangling‐capture in TestNodeConfig::complete_func to eliminate flaky IDLE returns

### DIFF
--- a/include/behaviortree_cpp/actions/test_node.h
+++ b/include/behaviortree_cpp/actions/test_node.h
@@ -39,7 +39,7 @@ struct TestNodeConfig
 
   /// Function invoked when the action is completed. By default just return [return_status]
   /// Override it to intorduce more comple cases
-  std::function<NodeStatus(void)> complete_func = [this]() { return return_status; };
+  std::function<NodeStatus(void)> complete_func = [ret = return_status]() { return ret; };
 };
 
 /**


### PR DESCRIPTION
# Summary
When using TestNode for JSON-driven substitution rules, the default complete_func lambda in
TestNodeConfig was capturing this (the address of a temporary). After move-constructing into the member _test_config, that pointer became dangling and often returned IDLE from onRunning(), triggering a LogicError. This patch changes the capture to copy return_status by value, fully eliminating the UB and making the test nodes reliably return SUCCESS or FAILURE as configured.

# Background / Motivation

Reported in issue #927: “TestNode sometimes returns IDLE onRunning()”
Reproduced in a minimal repo: test nodes intermittently returned IDLE even when configured for SUCCESS
Added file/minitrace loggers, saw onRunning() → IDLE and confirmed it came from complete_func()
Debugging revealed `complete_func = [this](){…}` pointed at a destroyed temporary
Changes

```
--- a/include/behaviortree_cpp/test_node.h
+++ b/include/behaviortree_cpp/test_node.h
@@ struct TestNodeConfig
-  std::function<NodeStatus(void)> complete_func = [this]() { return return_status; };
+  /// Capture return_status by value to avoid dangling this-pointer
+  std::function<NodeStatus(void)> complete_func = [ret = return_status]() { return ret; };
```

Before:
```
onStart() → RUNNING
onRunning() → complete_func() returns IDLE  ← UB, crashes
```
After:
```
onStart() → RUNNING
onRunning() → complete_func() returns SUCCESS ← correct
```
# Testing
Added file- and minitrace-logger in user code to capture every tick.
Wrote a small BT with a single <Action ID="Test" …/> substituted via JSON.
Verified 1st tick RUNNING, 2nd tick SUCCESS.
Ran full scenario suite — no more LogicError.



Related issues Issues:
#927: https://github.com/BehaviorTree/BehaviorTree.CPP/issues/927
and maybe
#930:  https://github.com/BehaviorTree/BehaviorTree.CPP/issues/930


Thanks for reviewing 🙏 Let me know if you’d like any tweaks!