### PR TITLE
Add action to publish Doxygen documentation as GH Page

### DIFF
--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -1,0 +1,18 @@
+name: Doxygen GitHub Pages Deploy Action
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: DenverCoder1/doxygen-github-pages-action@v2.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          folder: doc/html

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ to visualize, record, replay and analyze state transitions.
 
 You can learn about the main concepts, the API and the tutorials here: https://www.behaviortree.dev/
 
+An automatically generated API documentation can be found here: https://BehaviorTree.github.io/BehaviorTree.CPP/
+
 If the documentation doesn't answer your questions and/or you want to
 connect with the other **BT.CPP** users, visit [our forum](https://github.com/BehaviorTree/BehaviorTree.CPP/discussions)
 


### PR DESCRIPTION
Unfortunately, the docs on the website are quite incomplete regarding the Nodes that come with the library (see issue https://github.com/BehaviorTree/BehaviorTree.CPP/issues/649). I didn't see the latest docs hosted anywhere, so this adds a GH Action to build the Doxygen docs and publish it as this repo's GH page.

To have the page actually published, go to this repo's _Settings_ page after the Action has been run at least once. In the sidebar on the left, navigate to _Pages_, and select _Deploy from a branch_. Select the `gh-pages` branch and the `/ (root)` directory, like so:
![Screenshot from 2025-05-08 09-56-00](https://github.com/user-attachments/assets/49ba9b62-1cc5-4657-9bc8-d09d75d9f84d)

Now, it should be available under https://BehaviorTree.github.io/BehaviorTree.CPP/ .