### PR TITLE
fix: Make impossible to accidently copy JsonExporter singleton

### DIFF
--- a/include/behaviortree_cpp/json_export.h
+++ b/include/behaviortree_cpp/json_export.h
@@ -51,6 +51,10 @@ class JsonExporter
 public:
   static JsonExporter& get();
 
+  // Delete copy constructors as can only be this one global instance.
+  JsonExporter& operator=(JsonExporter&&) = delete;
+  JsonExporter& operator=(JsonExporter&) = delete;
+
   /**
    * @brief toJson adds the content of "any" to the JSON "destination".
    *


### PR DESCRIPTION
<!--
You must run clang-format, otherwise your change may not pass the tests on CI
We recommend using pre-commit.

To use:
    pre-commit run -a
Or:
     pre-commit install  # (runs every time you commit in git)

See https://github.com/pre-commit/pre-commit
-->

Make it impossible to copy the `JsonExporter` accidentally. The following snippet currently compiles and runs fine, however will not actually add the converters as it is working with a copy, so not produce the desired output.

```cpp
auto json_exporter = JsonExporter::get();
json_exporter.addConverter<MyType>();
```

With this change it will throw a compiler error.