### PR TITLE
fix: exclude 3rd party libraries from sonar issue tracking

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,3 +11,4 @@ sonar.organization=behaviortree
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
+sonar.exclusions=3rdparty/**/*


### PR DESCRIPTION
hello! i think this should exclude the 3rd party libraries from the issues report since that's not issues with the BTCPP code base.
<!--
You must run clang-format, otherwise your change may not pass the tests on CI
We recommend using pre-commit.

To use:
    pre-commit run -a
Or:
     pre-commit install  # (runs every time you commit in git)

See https://github.com/pre-commit/pre-commit
-->
