### PR TITLE
Set current_child_idx of SequenceNode protected

### DIFF
--- a/include/behaviortree_cpp/controls/sequence_node.h
+++ b/include/behaviortree_cpp/controls/sequence_node.h
@@ -40,8 +40,10 @@ public:
 
   virtual void halt() override;
 
-private:
+protected:
   size_t current_child_idx_;
+
+private:
   size_t skipped_count_ = 0;
   bool asynch_ = false;
 


### PR DESCRIPTION
My team has implemented a [`SequenceWithBlackboardMemory` node](https://github.com/ros-navigation/navigation2/pull/5247), which does almost exactly the same as the original Sequence node, except that it stores the current_child_idx on the blackboard. It would be nice to reuse the original class for this, but that variable is private. I set it to protected in this PR.

I think it could be useful elsewhere too, like the `SequenceWithMemory` node in this repo could be simplified.