### PR TITLE
Add convertFromString<vector<bool>>

### DIFF
--- a/include/behaviortree_cpp/basic_types.h
+++ b/include/behaviortree_cpp/basic_types.h
@@ -183,6 +183,10 @@ template <>
 template <>
 [[nodiscard]] std::vector<double> convertFromString<std::vector<double>>(StringView str);
 
+// Boolean values separated by the character ";"
+template <>
+[[nodiscard]] std::vector<bool> convertFromString<std::vector<bool>>(StringView str);
+
 // Strings separated by the character ";"
 template <>
 [[nodiscard]] std::vector<std::string>

--- a/src/basic_types.cpp
+++ b/src/basic_types.cpp
@@ -238,6 +238,19 @@ std::vector<double> convertFromString<std::vector<double>>(StringView str)
 }
 
 template <>
+std::vector<bool> convertFromString<std::vector<bool>>(StringView str)
+{
+  auto parts = splitString(str, ';');
+  std::vector<bool> output;
+  output.reserve(parts.size());
+  for(const StringView& part : parts)
+  {
+    output.push_back(convertFromString<bool>(part));
+  }
+  return output;
+}
+
+template <>
 std::vector<std::string> convertFromString<std::vector<std::string>>(StringView str)
 {
   auto parts = splitString(str, ';');


### PR DESCRIPTION
Functions exist in the library for conversions from string to
- `int` and `vector<int>`
- `double` and `vector<double>`
- `string` and `vector<string>`
- `bool` **but not for** `vector<bool>`,

so I added `convertFromString<vector<bool>>` to the library for completion and convenience.

---

Also, as mentioned in https://github.com/BehaviorTree/BehaviorTree.CPP/issues/953, user-defined conversion functions seem to be tricky to make available to use with plugins, this solves at least a certain case of the problem.