### PR TITLE
Make sequence node inheritable

### DIFF
--- a/include/behaviortree_cpp/controls/sequence_node.h
+++ b/include/behaviortree_cpp/controls/sequence_node.h
@@ -34,9 +34,8 @@ namespace BT
 class SequenceNode : public ControlNode
 {
 public:
-  SequenceNode(
-    const std::string& name, bool make_async = false,
-    const NodeConfiguration& conf = NodeConfiguration());
+  SequenceNode(const std::string& name, bool make_async = false,
+               const NodeConfiguration& conf = NodeConfiguration());
 
   virtual ~SequenceNode() override = default;
 

--- a/src/controls/sequence_node.cpp
+++ b/src/controls/sequence_node.cpp
@@ -15,7 +15,8 @@
 
 namespace BT
 {
-SequenceNode::SequenceNode(const std::string& name, bool make_async, const NodeConfiguration& conf)
+SequenceNode::SequenceNode(const std::string& name, bool make_async,
+                           const NodeConfiguration& conf)
   : ControlNode::ControlNode(name, conf), current_child_idx_(0), asynch_(make_async)
 {
   if(asynch_)


### PR DESCRIPTION
Another PR following up on #991. Turns out more changes were needed to allow other nodes inherit from `SequenceNode`.

The derived class has to call the `tick` method of the base class. If instead I call `executeTick`, the overwritten `tick` function is called, resulting in infinite recursion.

Also, the node configuration has to be passed to the `ControlNode`, otherwise the blackboard can't see the variables set for the node. I don't know why this is, if this is not the way, some would be appreciated on how to do this properly.

Needed for https://github.com/ros-navigation/navigation2/pull/5247