### PR TITLE
fix: use dynamically growing error buffer in ParseScript

### DIFF
--- a/src/script_parser.cpp
+++ b/src/script_parser.cpp
@@ -70,11 +70,12 @@ BT::Expected<Any> ParseScriptAndExecute(Ast::Environment& env, const std::string
 
 Result ValidateScript(const std::string& script)
 {
-  char error_msgs_buffer[2048];
+  std::string error_msgs_buffer;  // dynamically growing error buffer
 
   auto input = lexy::string_input<lexy::utf8_encoding>(script);
-  auto result =
-      lexy::parse<BT::Grammar::stmt>(input, ErrorReport().to(error_msgs_buffer));
+
+  auto reporter = ErrorReport().to(std::back_inserter(error_msgs_buffer));
+  auto result = lexy::parse<BT::Grammar::stmt>(input, reporter);
   if(result.has_value() && result.error_count() == 0)
   {
     try


### PR DESCRIPTION
fix bug in #1006 