### PR TITLE
Add support for sanitizers, including some GHAs

### DIFF
--- a/.github/workflows/cmake_ubuntu_aubsan.yml
+++ b/.github/workflows/cmake_ubuntu_aubsan.yml
@@ -1,0 +1,57 @@
+name: cmake Ubuntu with Address and Undefined Behavior Sanitizers
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Debug
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Conan
+      id: conan
+      uses: turtlebrowser/get-conan@main
+
+    - name: Create default profile
+      run: conan profile detect
+
+    - name: Install conan dependencies
+      run: conan install conanfile.py -s build_type=${{env.BUILD_TYPE}} --build=missing
+
+    - name: Normalize build type
+      shell: bash
+      # The build type is Capitalized, e.g. Release, but the preset is all lowercase, e.g. release.
+      # There is no built in way to do string manipulations on GHA as far as I know.`
+      run: echo "BUILD_TYPE_LOWERCASE=$(echo "${BUILD_TYPE}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+    - name: Configure CMake
+      shell: bash
+      run: cmake --preset conan-${{ env.BUILD_TYPE_LOWERCASE }} -DBTCPP_ENABLE_ASAN:BOOL=ON -DBTCPP_ENABLE_UBSAN:BOOL=ON
+
+    - name: Build
+      shell: bash
+      run: cmake --build --preset conan-${{ env.BUILD_TYPE_LOWERCASE }}
+
+    - name: run test (Linux + Address and Undefined Behavior Sanitizers)
+      env:
+        GTEST_COLOR: "On"
+        ASAN_OPTIONS: "color=always"
+        UBSAN_OPTIONS: "halt_on_error=1:print_stacktrace=1:color=always"
+      run: ctest --test-dir build/${{env.BUILD_TYPE}}

--- a/.github/workflows/cmake_ubuntu_tsan.yml
+++ b/.github/workflows/cmake_ubuntu_tsan.yml
@@ -1,0 +1,56 @@
+name: cmake Ubuntu with Thread Sanitizer
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Debug
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Conan
+      id: conan
+      uses: turtlebrowser/get-conan@main
+
+    - name: Create default profile
+      run: conan profile detect
+
+    - name: Install conan dependencies
+      run: conan install conanfile.py -s build_type=${{env.BUILD_TYPE}} --build=missing
+
+    - name: Normalize build type
+      shell: bash
+      # The build type is Capitalized, e.g. Release, but the preset is all lowercase, e.g. release.
+      # There is no built in way to do string manipulations on GHA as far as I know.`
+      run: echo "BUILD_TYPE_LOWERCASE=$(echo "${BUILD_TYPE}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+    - name: Configure CMake
+      shell: bash
+      run: cmake --preset conan-${{ env.BUILD_TYPE_LOWERCASE }} -DBTCPP_ENABLE_TSAN:BOOL=ON
+
+    - name: Build
+      shell: bash
+      run: cmake --build --preset conan-${{ env.BUILD_TYPE_LOWERCASE }}
+
+    - name: run test (Linux + Thread Sanitizer)
+      env:
+        GTEST_COLOR: "On"
+        TSAN_OPTIONS: "color=always"
+      run: sudo sysctl vm.mmap_rnd_bits=28 && ctest --test-dir build/${{env.BUILD_TYPE}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ option(BTCPP_EXAMPLES   "Build tutorials and examples" ON)
 option(BUILD_TESTING "Build the unit tests" ON)
 option(BTCPP_GROOT_INTERFACE "Add Groot2 connection. Requires ZeroMQ" ON)
 option(BTCPP_SQLITE_LOGGING "Add SQLite logging." ON)
+option(BTCPP_ENABLE_ASAN "Enable Address Sanitizer" OFF)
+option(BTCPP_ENABLE_UBSAN "Enable Undefined Behavior Sanitizer" OFF)
+option(BTCPP_ENABLE_TSAN "Enable Thread Sanitizer" OFF)
 
 option(USE_V3_COMPATIBLE_NAMES  "Use some alias to compile more easily old 3.x code" OFF)
 option(ENABLE_FUZZING "Enable fuzzing builds" OFF)
@@ -53,6 +56,8 @@ endif()
 
 set(CMAKE_CONFIG_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CONFIG_PATH}")
+
+include(sanitizers)
 
 set(BTCPP_LIBRARY ${PROJECT_NAME})
 

--- a/cmake/sanitizers.cmake
+++ b/cmake/sanitizers.cmake
@@ -1,0 +1,30 @@
+if(BTCPP_ENABLE_ASAN OR BTCPP_ENABLE_UBSAN OR BTCPP_ENABLE_TSAN)
+    if(NOT CMAKE_BUILD_TYPE MATCHES "Debug|RelWithDebInfo")
+        message(FATAL_ERROR "Sanitizers require debug symbols. Please set CMAKE_BUILD_TYPE to Debug or RelWithDebInfo.")
+    endif()
+    add_compile_options(-fno-omit-frame-pointer)
+endif()
+
+# Address Sanitizer and Undefined Behavior Sanitizer can be run at the same time.
+# Thread Sanitizer requires its own build.
+if(BTCPP_ENABLE_TSAN AND (BTCPP_ENABLE_ASAN OR BTCPP_ENABLE_UBSAN))
+    message(FATAL_ERROR "TSAN is not compatible with ASAN or UBSAN. Please enable only one of them.")
+endif()
+
+if(BTCPP_ENABLE_ASAN)
+    message(STATUS "Address Sanitizer enabled")
+    add_compile_options(-fsanitize=address)
+    add_link_options(-fsanitize=address)
+endif()
+
+if(BTCPP_ENABLE_UBSAN)
+    message(STATUS "Undefined Behavior Sanitizer enabled")
+    add_compile_options(-fsanitize=undefined)
+    add_link_options(-fsanitize=undefined)
+endif()
+
+if(BTCPP_ENABLE_TSAN)
+    message(STATUS "Thread Sanitizer enabled")
+    add_compile_options(-fsanitize=thread)
+    add_link_options(-fsanitize=thread)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,15 +43,18 @@ if(ament_cmake_FOUND)
 
 else()
 
-    find_package(GTest REQUIRED)
-
     enable_testing()
+
+    find_package(GTest REQUIRED)
+    include(GoogleTest)
+
     add_executable(behaviortree_cpp_test ${BT_TESTS})
-    add_test(NAME btcpp_test COMMAND behaviortree_cpp_test)
 
     target_link_libraries(behaviortree_cpp_test
         GTest::gtest
         GTest::gtest_main)
+
+    gtest_discover_tests(behaviortree_cpp_test)
 
 endif()
 


### PR DESCRIPTION
Add support for Address, Undefined Behavior and Thread sanitizer.

I've also included 2 new GHAs that will run on PR builds, one with ASan and UBsan and a separate one with TSan, since this sanitizer is not compatible with the previous two.

I also lightly tweaked how tests are registered to use a more modern approach, which lets gtest query the test target to figure out how many unit tests it has and registers them individually instead of as a monolithic test. This speeds up the testing since all tests can now run in parallel, but also allows the test suite to continue running if a test failed. So a developer can identify multiple issues on a single run. As it is now the first failure aborts the test run. 

TODO: docs. This is just a draft to validate the GHAs.