### PR TITLE
Include `curses.h` instead of `ncurses.h`

### DIFF
--- a/src/controls/manual_node.cpp
+++ b/src/controls/manual_node.cpp
@@ -13,7 +13,7 @@
 
 #include "behaviortree_cpp/controls/manual_node.h"
 #include "behaviortree_cpp/action_node.h"
-#include <ncurses.h>
+#include <curses.h>
 
 namespace BT
 {


### PR DESCRIPTION
`ncurses.h` is usually a symlink to the actual header, `curses.h`. See also https://stackoverflow.com/questions/59555474/difference-between-the-headers-ncurses-h-and-curses-h

When building with Bazel (thanks @kgreenek for adding in https://github.com/bazelbuild/bazel-central-registry/pull/5154), you (currently) want to depend on `curses.h`, otherwise you may end up depending on a host installed version accidentally