### PR TITLE
Properly mark sqlite3 and cppzmq as public dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,9 +231,9 @@ target_link_libraries(${BTCPP_LIBRARY}
         tinyxml2::tinyxml2
         minicoro::minicoro
         flatbuffers::flatbuffers
+    PUBLIC
         $<$<BOOL:${BTCPP_GROOT_INTERFACE}>:cppzmq>
         $<$<BOOL:${BTCPP_SQLITE_LOGGING}>:SQLite::SQLite3>
-    PUBLIC
         ${BTCPP_EXTRA_LIBRARIES}
 )
 


### PR DESCRIPTION
I made them `PRIVATE` as a side effect of https://github.com/BehaviorTree/BehaviorTree.CPP/pull/1012 
This introduces linking issues on some scenarios (if bt and its dependencies are built as shared libs, then the targets that depend on bt like the tests, tools and examples fail to link with undef symbols).

