### PR TITLE
Event-based tree ticking

### DIFF
--- a/include/behaviortree_cpp/bt_factory.h
+++ b/include/behaviortree_cpp/bt_factory.h
@@ -119,13 +119,19 @@ public:
   [[nodiscard]] TreeNode* rootNode() const;
 
   /**
-    * @brief Sleep for a certain amount of time. This sleep could be interrupted by the method TreeNode::emitWakeUpSignal()
+    * @brief Sleep for a certain amount of time. This sleep could be interrupted by the methods
+    * TreeNode::emitWakeUpSignal() or Tree::emitWakeUpSignal()
     *
     * @param timeout  duration of the sleep
     * @return         true if the timeout was NOT reached and the signal was received.
     *
     * */
   bool sleep(std::chrono::system_clock::duration timeout);
+
+  /**
+   * @brief Wake up the tree. This will interrupt the sleep() method.
+   */
+  void emitWakeUpSignal();
 
   ~Tree();
 

--- a/src/bt_factory.cpp
+++ b/src/bt_factory.cpp
@@ -519,6 +519,11 @@ bool Tree::sleep(std::chrono::system_clock::duration timeout)
       std::chrono::duration_cast<std::chrono::milliseconds>(timeout));
 }
 
+void Tree::emitWakeUpSignal()
+{
+  wake_up_->emitSignal();
+}
+
 Tree::~Tree()
 {
   haltTree();


### PR DESCRIPTION
I have a tree, which checks some pre-conditions in our system state, using a ReactiveSequence, and executes some (re)actions if they are not met. The pre-conditions are checked using a simple custom node, which reads the system state.
I have a callback mechanism, which notifies me when the system state changes, and I would like to tick the tree based on these events instead of a fixed rate. The callbacks can be executed from different threads, so I would like to avoid ticking the tree in the callback directly.

What seems to work is something like this:

```
void ReactionManager::workerMain() {
  while (!exitWorkerLoop_) {
    tree_->tickOnce();
    tree_->sleep(std::chrono::milliseconds(10000));
  }
}

void ReactionManager::wakeupWorker() {
  if (tree_) {
    if (!tree_->subtrees.empty()) {
      auto& nodes = tree_->subtrees.front()->nodes;
      if (!nodes.empty()) {
        nodes.front()->emitWakeUpSignal();
      }
    }
  }
}
```
However, I wondered why the `Tree` itself does not have such a `emitWakeUpSignal`? This pull request adds this method.

