### PR TITLE
[fix] Make cppzmq as public dependency to avoid linkage errors for tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,7 @@ target_link_libraries(${BTCPP_LIBRARY}
 
 if(BTCPP_GROOT_INTERFACE)
     target_link_libraries(${BTCPP_LIBRARY}
-        PRIVATE
+        PUBLIC
             $<BUILD_INTERFACE:cppzmq>
     )
 endif()


### PR DESCRIPTION
Hello!

This PR is a follow-up to #1027 and it's related to #1025  

There is a scenario when using BehaviorTree.CPP and all its dependencies as shared libraries, and the option `BTCPP_BUILD_TOOLS=ON` it will produce the following error:

```
[43/43] : && /usr/bin/c++ -m64 -O3 -DNDEBUG -m64 tools/CMakeFiles/bt4_plugin_manifest.dir/bt_plugin_manifest.cpp.o -o tools/bt4_plugin_manifest  -Wl,-rpath,/home/uilian/.conan2/p/b/behav2964106e86ad1/b/build/Release:  libbehaviortree_cpp.so && :
FAILED: [code=1] tools/bt4_plugin_manifest 
: && /usr/bin/c++ -m64 -O3 -DNDEBUG -m64 tools/CMakeFiles/bt4_plugin_manifest.dir/bt_plugin_manifest.cpp.o -o tools/bt4_plugin_manifest  -Wl,-rpath,/home/uilian/.conan2/p/b/behav2964106e86ad1/b/build/Release:  libbehaviortree_cpp.so && :
/usr/bin/ld: warning: libsodium.so.26, needed by /home/uilian/.conan2/p/zerom4f1a70513bc3e/p/lib/libzmq.so.5, not found (try using -rpath or -rpath-link)
```

You can check my full build log for extra reference: [behaviortree.cpp-4.8.2-linux-gcc11-shared-tools.log](https://github.com/user-attachments/files/24172377/behaviortree.cpp-4.8.2-linux-gcc11-shared-tools.log)

It occurs because **cppmzq** is a header-only library whose implementation dependency (ZeroMQ) has its own shared library dependency (libsodium) that the linker cannot resolve transitively at link-time without explicit propagation due to `PRIVATE`. Other dependencies are libraries, so their symbols or paths are properly encoded in the shared library metadata.

When using external dependencies only, ZeroMQ is not listed as a direct dependency of BehaviorTree.CPP, because this project only consumes cppzmq, which has zeromq -> libsodium in its dependencies graph. And this is correct in terms of dependency management. 

This PR fixes the current scenario by exposing cppzmq as PUBLIC, so its dependencies will be available when linking to:

```
[43/43] : && /usr/bin/c++ -m64 -O3 -DNDEBUG -m64 tools/CMakeFiles/bt4_plugin_manifest.dir/bt_plugin_manifest.cpp.o -o tools/bt4_plugin_manifest -L/home/uilian/.conan2/p/zerom4f1a70513bc3e/p/lib   -L/home/uilian/.conan2/p/libso550d4741ed047/p/lib -Wl,-rpath,/home/uilian/.conan2/p/zerom4f1a70513bc3e/p/lib:/home/uilian/.conan2/p/libso550d4741ed047/p/lib:/home/uilian/.conan2/p/b/behavf1857de9aebc8/b/build/Release:  libbehaviortree_cpp.so  /home/uilian/.conan2/p/zerom4f1a70513bc3e/p/lib/libzmq.so  -lrt  -lm  -lpthread && :
```

You can check my full build log using this modification as well: [behaviortree.cpp-4.8.3-dev-linux-gcc11-shared-tools.log](https://github.com/user-attachments/files/24172463/behaviortree.cpp-4.8.3-dev-linux-gcc11-shared-tools.log)

You can observe now that the libsodum location is exposed during the linkage stage, and zeromq can find its dependency.

Please, feel free to share your thoughts. Regards. 

### Environment

BehaviorTree.CPP version: 4.8.2
OS: GNU/Linux Ubunut 24.04
Compiler: GNU GCC 11

