### PR TITLE
Generate `.clangd` in `PROJECT_SOURCE_DIR`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,17 +308,17 @@ endif()
 
 ######################################################
 # Generate .clangd configuration file for standalone header checking
-file(WRITE ${CMAKE_SOURCE_DIR}/.clangd
+file(WRITE ${PROJECT_SOURCE_DIR}/.clangd
 "CompileFlags:
   Add:
     - -xc++
     - -std=c++17
-    - -I${CMAKE_SOURCE_DIR}/include
-    - -I${CMAKE_SOURCE_DIR}/3rdparty
-    - -I${CMAKE_SOURCE_DIR}/3rdparty/minitrace
-    - -I${CMAKE_SOURCE_DIR}/3rdparty/tinyxml2
-    - -I${CMAKE_SOURCE_DIR}/3rdparty/minicoro
-    - -I${CMAKE_SOURCE_DIR}/3rdparty/lexy/include
+    - -I${PROJECT_SOURCE_DIR}/include
+    - -I${PROJECT_SOURCE_DIR}/3rdparty
+    - -I${PROJECT_SOURCE_DIR}/3rdparty/minitrace
+    - -I${PROJECT_SOURCE_DIR}/3rdparty/tinyxml2
+    - -I${PROJECT_SOURCE_DIR}/3rdparty/minicoro
+    - -I${PROJECT_SOURCE_DIR}/3rdparty/lexy/include
 ")
 
 ######################################################


### PR DESCRIPTION
## Summary

This change replaces `CMAKE_SOURCE_DIR` by `PROJECT_SOURCE_DIR` in the code that generates the `.clangd` file in `CMakeLists.txt`.

## Motivation

`CMAKE_SOURCE_DIR` is the source directory that was given on the invocation of CMake.  When including `BT.CPP` in other projects, through git submodules, CMake `FetchContent` or `CPM`, the project is not often not at the root of the sources. In that case, the `.clangd` file is most likely incorrect and the include paths relative to `CMAKE_SOURCE_DIR` are too.

Furthermore, it may overwrite the `.clangd` file in the root project that includes `BT.CPP` which is unwanted.

## Impacts

There should be not impact on API, ABI or tests.