### PR TITLE
Remove use of `std::aligned_storage` in any.hpp

### DIFF
--- a/include/behaviortree_cpp/contrib/any.hpp
+++ b/include/behaviortree_cpp/contrib/any.hpp
@@ -21,6 +21,7 @@
 #include <stdexcept>
 #include <utility>
 #include <new>
+#include <array>
 
 #if defined(PARTICLE)
 #if !defined(__cpp_exceptions) && !defined(ANY_IMPL_NO_EXCEPTIONS) && !defined(ANY_IMPL_EXCEPTIONS)
@@ -211,7 +212,7 @@ private: // Storage and Virtual Method Table
 
     union storage_union
     {
-        using stack_storage_t = typename std::aligned_storage<2 * sizeof(void*), std::alignment_of<void*>::value>::type;
+        struct alignas(void*) stack_storage_t : std::array<std::byte, 2 * sizeof(void*)> {};
 
         void*               dynamic;
         stack_storage_t     stack;      // 2 words for e.g. shared_ptr


### PR DESCRIPTION
## Summary

This change removes the use of the `std::aligned_storage` type in `contrib/any.hpp` and replaces it with a struct with an explicit alignment requirement inheriting an array of bytes of the right size. 

## Motivation

The `std::aligned_storage` type has been deprecated in C++23, which may cause warnings in client code using the `any.hpp` header directly or indirectly.

References for this change are this [stackoverflow discussion](https://stackoverflow.com/questions/71828288/why-is-stdaligned-storage-to-be-deprecated-in-c23-and-what-to-use-instead) and the [paper P1413R3](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p1413r3.pdf) that suggested the deprecation.

In that paper, the suggested change is the following:
```diff
- std::aligned_storage_t<sizeof(T), alignof(T)> t_buff;
+ alignas(T) std::byte t_buff[sizeof(T)];
```

However in the context of the library and its clang-tidy rules (in this case, `modernize-*` rules) generate a warning with C-arrays and advise using a `std::array` instead.

## Impacts on API / ABI

There is no impact on API, and as far as I know it should be ABI compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal storage implementation to enhance memory alignment handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->