### PR TITLE
Fix #1029: correct left-associativity for arithmetic operators

### DIFF
--- a/include/behaviortree_cpp/scripting/operators.hpp
+++ b/include/behaviortree_cpp/scripting/operators.hpp
@@ -747,7 +747,10 @@ struct Expression : lexy::expression_production
       return dsl::op<Ast::ExprBinaryArithmetic::concat>(LEXY_LIT(".."));
     }();
 
-    using operand = math_sum;
+    // Use math_prefix (not math_sum) to avoid duplicating math_sum/math_product
+    // in the operation list, which would break left-associativity of +/-/*//
+    // due to conflicting binding power levels in lexy's _operation_list_of.
+    using operand = math_prefix;
   };
 
   // ~x


### PR DESCRIPTION
## Summary
- Fix left-to-right associativity for `+`, `-`, `*`, `/` operators in the script parser
- `A - B + C` was incorrectly evaluated as `A - (B + C)` due to conflicting binding power levels in lexy's operation list
- Adds regression tests for arithmetic associativity

## Test plan
- [x] New test: `ScriptParser.Associativity_Issue1029`
- [x] All existing tests pass (298/298)

Closes #1029

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed operator associativity handling in scripting, resolving precedence conflicts with string concatenation and arithmetic operations.

* **Tests**
  * Added test suite validating left-associativity for arithmetic and string operations (Issue1029).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->