### PR TITLE
Fix #982: vector initialized with json:[] string instead of empty

### DIFF
--- a/src/basic_types.cpp
+++ b/src/basic_types.cpp
@@ -222,6 +222,11 @@ float convertFromString<float>(StringView str)
 template <>
 std::vector<int> convertFromString<std::vector<int>>(StringView str)
 {
+  if(StartWith(str, "json:"))
+  {
+    str.remove_prefix(5);
+    return nlohmann::json::parse(str).get<std::vector<int>>();
+  }
   auto parts = splitString(str, ';');
   std::vector<int> output;
   output.reserve(parts.size());
@@ -235,6 +240,11 @@ std::vector<int> convertFromString<std::vector<int>>(StringView str)
 template <>
 std::vector<double> convertFromString<std::vector<double>>(StringView str)
 {
+  if(StartWith(str, "json:"))
+  {
+    str.remove_prefix(5);
+    return nlohmann::json::parse(str).get<std::vector<double>>();
+  }
   auto parts = splitString(str, ';');
   std::vector<double> output;
   output.reserve(parts.size());
@@ -248,6 +258,11 @@ std::vector<double> convertFromString<std::vector<double>>(StringView str)
 template <>
 std::vector<bool> convertFromString<std::vector<bool>>(StringView str)
 {
+  if(StartWith(str, "json:"))
+  {
+    str.remove_prefix(5);
+    return nlohmann::json::parse(str).get<std::vector<bool>>();
+  }
   auto parts = splitString(str, ';');
   std::vector<bool> output;
   output.reserve(parts.size());
@@ -261,6 +276,11 @@ std::vector<bool> convertFromString<std::vector<bool>>(StringView str)
 template <>
 std::vector<std::string> convertFromString<std::vector<std::string>>(StringView str)
 {
+  if(StartWith(str, "json:"))
+  {
+    str.remove_prefix(5);
+    return nlohmann::json::parse(str).get<std::vector<std::string>>();
+  }
   auto parts = splitString(str, ';');
   std::vector<std::string> output;
   output.reserve(parts.size());

--- a/tests/gtest_ports.cpp
+++ b/tests/gtest_ports.cpp
@@ -665,3 +665,60 @@ TEST(PortTest, LoopNodeAcceptsVector_Issue969)
   EXPECT_DOUBLE_EQ(collected[1], 20.0);
   EXPECT_DOUBLE_EQ(collected[2], 30.0);
 }
+
+// Issue #982: A port of type std::vector<std::string> with a default empty value {}
+// gets initialized with the literal string "json:[]" instead of being empty.
+// This happens because toStr() converts {} to "json:[]", and the vector
+// convertFromString specialization doesn't handle the "json:" prefix.
+class ActionWithDefaultEmptyVector : public SyncActionNode
+{
+public:
+  ActionWithDefaultEmptyVector(const std::string& name, const NodeConfig& config,
+                               std::vector<std::string>* out_vec)
+    : SyncActionNode(name, config), out_vec_(out_vec)
+  {}
+
+  NodeStatus tick() override
+  {
+    if(!getInput("string_vector", *out_vec_))
+    {
+      return NodeStatus::FAILURE;
+    }
+    return NodeStatus::SUCCESS;
+  }
+
+  static PortsList providedPorts()
+  {
+    return { BT::InputPort<std::vector<std::string>>("string_vector", {},
+                                                     "A string vector") };
+  }
+
+private:
+  std::vector<std::string>* out_vec_;
+};
+
+TEST(PortTest, DefaultEmptyVector_Issue982)
+{
+  // Port has default value {} (empty vector) and no input specified in XML.
+  // The vector should be empty, not contain "json:[]".
+  std::string xml_txt = R"(
+    <root BTCPP_format="4">
+      <BehaviorTree ID="MainTree">
+        <ActionWithDefaultEmptyVector />
+      </BehaviorTree>
+    </root>
+  )";
+
+  std::vector<std::string> result;
+
+  BehaviorTreeFactory factory;
+  factory.registerNodeType<ActionWithDefaultEmptyVector>("ActionWithDefaultEmptyVector",
+                                                         &result);
+  auto tree = factory.createTreeFromText(xml_txt);
+  auto status = tree.tickWhileRunning();
+
+  ASSERT_EQ(status, NodeStatus::SUCCESS);
+  ASSERT_TRUE(result.empty()) << "Expected empty vector, but got " << result.size()
+                              << " element(s). First element: \""
+                              << (result.empty() ? "" : result[0]) << "\"";
+}


### PR DESCRIPTION
## Summary
- Fix std::vector<std::string> ports being initialized with literal json:[] string instead of empty vector
- Handle json: prefix correctly in convertFromString specializations for vector types

## Test plan
- [x] New test: PortTest.DefaultEmptyVector_Issue982
- [x] All existing tests pass (298/298)

Closes #982