### PR TITLE
Fix #969: LoopNode std::vector<T> vs std::deque<T> type mismatch

### DIFF
--- a/tests/gtest_ports.cpp
+++ b/tests/gtest_ports.cpp
@@ -581,3 +581,87 @@ TEST(PortTest, DefaultWronglyOverriden)
   // This is correct
   ASSERT_NO_THROW(auto tree = factory.createTreeFromText(xml_txt_correct));
 }
+
+// Helper class used by Issue #969 test
+class CollectDoubleAction : public SyncActionNode
+{
+public:
+  CollectDoubleAction(const std::string& name, const NodeConfig& config,
+                      std::vector<double>* collected)
+    : SyncActionNode(name, config), collected_(collected)
+  {}
+
+  NodeStatus tick() override
+  {
+    double val = 0;
+    if(getInput("value", val))
+    {
+      collected_->push_back(val);
+      return NodeStatus::SUCCESS;
+    }
+    return NodeStatus::FAILURE;
+  }
+
+  static PortsList providedPorts()
+  {
+    return { BT::InputPort<double>("value") };
+  }
+
+private:
+  std::vector<double>* collected_;
+};
+
+// Issue #969: LoopNode<T> uses SharedQueue<T> (shared_ptr<deque<T>>) for its queue
+// port, but upstream nodes often produce std::vector<T>. This type mismatch causes
+// tree creation to fail.
+class ProduceVectorDoubleAction : public SyncActionNode
+{
+public:
+  ProduceVectorDoubleAction(const std::string& name, const NodeConfig& config)
+    : SyncActionNode(name, config)
+  {}
+
+  NodeStatus tick() override
+  {
+    std::vector<double> vec = { 10.0, 20.0, 30.0 };
+    setOutput("numbers", vec);
+    return NodeStatus::SUCCESS;
+  }
+
+  static PortsList providedPorts()
+  {
+    return { BT::OutputPort<std::vector<double>>("numbers") };
+  }
+};
+
+TEST(PortTest, LoopNodeAcceptsVector_Issue969)
+{
+  // An upstream node outputs std::vector<double>, and LoopDouble should be
+  // able to iterate over it without requiring manual conversion to SharedQueue.
+  std::string xml_txt = R"(
+    <root BTCPP_format="4">
+      <BehaviorTree ID="MainTree">
+        <Sequence>
+          <ProduceVectorDouble numbers="{nums}" />
+          <LoopDouble queue="{nums}" value="{val}">
+            <CollectDouble value="{val}" />
+          </LoopDouble>
+        </Sequence>
+      </BehaviorTree>
+    </root>
+  )";
+
+  std::vector<double> collected;
+
+  BehaviorTreeFactory factory;
+  factory.registerNodeType<ProduceVectorDoubleAction>("ProduceVectorDouble");
+  factory.registerNodeType<CollectDoubleAction>("CollectDouble", &collected);
+  auto tree = factory.createTreeFromText(xml_txt);
+  auto status = tree.tickWhileRunning();
+
+  ASSERT_EQ(status, NodeStatus::SUCCESS);
+  ASSERT_EQ(collected.size(), 3u);
+  EXPECT_DOUBLE_EQ(collected[0], 10.0);
+  EXPECT_DOUBLE_EQ(collected[1], 20.0);
+  EXPECT_DOUBLE_EQ(collected[2], 30.0);
+}


### PR DESCRIPTION
## Summary
- LoopNode<T> now accepts std::vector<T> in addition to SharedQueue<T> (deque) for its queue port
- Resolves port type conflict when upstream nodes produce std::vector<T>

## Test plan
- [x] New test: PortTest.LoopNodeAcceptsVector_Issue969
- [x] All existing tests pass (298/298)

Closes #969