### PR TITLE
Fix #883: JSON braces no longer treated as blackboard variables

### DIFF
--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -801,9 +801,7 @@ TreeNode::Ptr XMLParser::PImpl::createNodeFromXML(const XMLElement* element,
         else
         {
           const auto& port_model = port_model_it->second;
-          const bool is_blackboard = port_value.size() >= 3 &&
-                                     port_value.front() == '{' &&
-                                     port_value.back() == '}';
+          const bool is_blackboard = TreeNode::isBlackboardPointer(port_value);
           // let's test already if conversion is possible
           if(!is_blackboard && port_model.converter() && port_model.isStronglyTyped())
           {


### PR DESCRIPTION
## Summary
- Enhanced `isBlackboardPointer()` to validate content between braces matches a valid variable name pattern (`[@]?[a-zA-Z_][a-zA-Z0-9_./]*`), rejecting JSON strings like `{"key": "value"}`
- Centralized the blackboard pointer check in `xml_parsing.cpp` to use `TreeNode::isBlackboardPointer()` instead of an inline brace check
- Added `PortTest.IsBlackboardPointer_Issue883` test covering valid pointers, JSON rejection, and edge cases

## Test plan
- [x] New test `PortTest.IsBlackboardPointer_Issue883` passes
- [x] All 322 existing tests pass (0 failures)
- [x] Pre-commit hooks (clang-format, codespell) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation for parameter expressions with stricter content checking and improved error detection for malformed inputs, ensuring more robust configuration processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->