### PR TITLE
Fix misleading static_assert when extra args have wrong type

### DIFF
--- a/include/behaviortree_cpp/bt_factory.h
+++ b/include/behaviortree_cpp/bt_factory.h
@@ -395,7 +395,20 @@ public:
                     "[registerNode]: you MUST implement the static method:\n"
                     "  PortsList providedPorts();\n");
 
-      static_assert(!(has_static_ports_list && !param_constructable),
+      // When extra arguments were passed to registerNodeType but the full
+      // constructor signature doesn't match, the problem is most likely a
+      // type mismatch in those extra arguments (issue #837).
+      static_assert(!(has_static_ports_list && !param_constructable
+                       && sizeof...(ExtraArgs) > 0),
+                    "[registerNode]: the constructor is NOT compatible with the "
+                    "arguments provided.\n"
+                    "Verify that the types of the extra arguments passed to "
+                    "registerNodeType match\n"
+                    "the constructor signature: "
+                    "(const std::string&, const NodeConfig&, ...)\n");
+
+      static_assert(!(has_static_ports_list && !param_constructable
+                       && sizeof...(ExtraArgs) == 0),
                     "[registerNode]: since you have a static method providedPorts(),\n"
                     "you MUST add a constructor with signature:\n"
                     "(const std::string&, const NodeConfig&)\n");


### PR DESCRIPTION
## Summary

- Fixes #837: When `registerNodeType<T>` is called with extra constructor arguments of the wrong type, the compiler now shows a helpful message ("the constructor is NOT compatible with the arguments provided") instead of the misleading "you MUST add a constructor with signature: (const std::string&, const NodeConfig&)"
- Splits the single `static_assert` into two: one for when extra args are provided (type mismatch), one for when no extra args are provided (missing constructor)
- Also removes stale `script_tokenizer.cpp` reference from CMakeLists.txt left by the lexy removal

## Test plan

- [ ] Verify compile-time error message with mismatched extra arg types shows new message
- [ ] Verify compile-time error message with missing constructor (no extra args) shows original message
- [ ] Verify library builds cleanly with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added stricter compile-time validation for node factory registration with improved error messages to catch constructor signature mismatches earlier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->