### PR TITLE
Fix #953: getInput() now uses stored converter for plugin custom types

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,19 @@
 ######################################################
 # TESTS
 
+######################################################
+# Plugin for Issue #953 test (must be built before tests)
+# This plugin has a custom type with convertFromString ONLY in the plugin
+add_library(plugin_issue953 SHARED plugin_issue953/plugin_issue953.cpp)
+target_compile_definitions(plugin_issue953 PRIVATE BT_PLUGIN_EXPORT)
+set_target_properties(plugin_issue953 PROPERTIES
+  PREFIX ""
+  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+)
+target_link_libraries(plugin_issue953 ${BTCPP_LIBRARY})
+
+######################################################
+
 set(BT_TESTS
   src/action_test_node.cpp
   src/condition_test_node.cpp
@@ -38,6 +51,7 @@ set(BT_TESTS
   gtest_while_do_else.cpp
   gtest_interface.cpp
   gtest_simple_string.cpp
+  gtest_plugin_issue953.cpp
 
   script_parser_test.cpp
   test_helper.hpp
@@ -79,3 +93,9 @@ endif()
 target_include_directories(behaviortree_cpp_test PRIVATE include)
 target_link_libraries(behaviortree_cpp_test ${BTCPP_LIBRARY} bt_sample_nodes foonathan::lexy)
 target_compile_definitions(behaviortree_cpp_test PRIVATE BT_TEST_FOLDER="${CMAKE_CURRENT_SOURCE_DIR}")
+
+# Ensure plugin is built before tests run, and tests can find it
+add_dependencies(behaviortree_cpp_test plugin_issue953)
+target_compile_definitions(behaviortree_cpp_test PRIVATE
+  BT_PLUGIN_ISSUE953_PATH="$<TARGET_FILE:plugin_issue953>"
+)

--- a/tests/gtest_plugin_issue953.cpp
+++ b/tests/gtest_plugin_issue953.cpp
@@ -1,0 +1,137 @@
+/**
+ * Test for Issue #953: convertFromString specialization in plugins not visible
+ * to main application.
+ *
+ * This test loads a plugin (plugin_issue953.so) that defines:
+ * - A custom type (Issue953Type)
+ * - The convertFromString<Issue953Type> specialization (ONLY in the plugin)
+ * - An action node that uses getInput<Issue953Type>()
+ *
+ * The key point: this test file does NOT have access to the convertFromString
+ * specialization. Before the fix, getInput() would fail. After the fix, it
+ * works because the StringConverter is stored in PortInfo.
+ */
+
+#include "behaviortree_cpp/bt_factory.h"
+
+#include <filesystem>
+
+#include <gtest/gtest.h>
+
+using namespace BT;
+
+// Plugin path is defined at compile time via CMake
+#ifndef BT_PLUGIN_ISSUE953_PATH
+#define BT_PLUGIN_ISSUE953_PATH "plugin_issue953.so"
+#endif
+
+class PluginIssue953Test : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    plugin_path_ = BT_PLUGIN_ISSUE953_PATH;
+
+    if(!std::filesystem::exists(plugin_path_))
+    {
+      GTEST_SKIP() << "Plugin not found at: " << plugin_path_ << ". "
+                   << "Make sure it's built before running this test.";
+    }
+  }
+
+  std::string plugin_path_;
+};
+
+// Test that getInput works for a custom type defined only in the plugin
+TEST_F(PluginIssue953Test, GetInputUsesStoredConverter)
+{
+  // This XML uses a literal string value for the input port
+  const char* xml_text = R"(
+    <root BTCPP_format="4">
+      <BehaviorTree ID="MainTree">
+        <Issue953Action input="42;hello_world;3.14159"/>
+      </BehaviorTree>
+    </root>
+  )";
+
+  BehaviorTreeFactory factory;
+
+  // Load the plugin - this registers Issue953Action
+  // The plugin has the convertFromString<Issue953Type> specialization,
+  // but THIS file does not.
+  factory.registerFromPlugin(plugin_path_);
+
+  auto tree = factory.createTreeFromText(xml_text);
+
+  // This should work because:
+  // 1. InputPort<Issue953Type>() was called in the plugin
+  // 2. GetAnyFromStringFunctor captured convertFromString at that point
+  // 3. The fix makes getInput() use that stored converter
+  auto status = tree.tickWhileRunning();
+
+  ASSERT_EQ(status, NodeStatus::SUCCESS);
+
+  // Verify the parsed values via output ports
+  auto bb = tree.rootBlackboard();
+  EXPECT_EQ(bb->get<int>("out_id"), 42);
+  EXPECT_EQ(bb->get<std::string>("out_name"), "hello_world");
+  EXPECT_DOUBLE_EQ(bb->get<double>("out_value"), 3.14159);
+}
+
+// Test with blackboard - value stored as string, then parsed on read
+TEST_F(PluginIssue953Test, GetInputFromBlackboardString)
+{
+  const char* xml_text = R"(
+    <root BTCPP_format="4">
+      <BehaviorTree ID="MainTree">
+        <Sequence>
+          <Script code="my_data := '99;from_script;2.718'" />
+          <Issue953Action input="{my_data}"/>
+        </Sequence>
+      </BehaviorTree>
+    </root>
+  )";
+
+  BehaviorTreeFactory factory;
+  factory.registerFromPlugin(plugin_path_);
+
+  auto tree = factory.createTreeFromText(xml_text);
+  auto status = tree.tickWhileRunning();
+
+  ASSERT_EQ(status, NodeStatus::SUCCESS);
+
+  auto bb = tree.rootBlackboard();
+  EXPECT_EQ(bb->get<int>("out_id"), 99);
+  EXPECT_EQ(bb->get<std::string>("out_name"), "from_script");
+  EXPECT_DOUBLE_EQ(bb->get<double>("out_value"), 2.718);
+}
+
+// Test with SubTree port remapping
+TEST_F(PluginIssue953Test, GetInputViaSubtreeRemapping)
+{
+  const char* xml_text = R"(
+    <root BTCPP_format="4" main_tree_to_execute="MainTree">
+      <BehaviorTree ID="MainTree">
+        <SubTree ID="Issue953SubTree" data="123;subtree_test;1.5"/>
+      </BehaviorTree>
+
+      <BehaviorTree ID="Issue953SubTree">
+        <Issue953Action input="{data}"/>
+      </BehaviorTree>
+    </root>
+  )";
+
+  BehaviorTreeFactory factory;
+  factory.registerFromPlugin(plugin_path_);
+
+  auto tree = factory.createTreeFromText(xml_text);
+  auto status = tree.tickWhileRunning();
+
+  ASSERT_EQ(status, NodeStatus::SUCCESS);
+
+  // Get the subtree's blackboard to check output
+  auto subtree_bb = tree.subtrees[1]->blackboard;
+  EXPECT_EQ(subtree_bb->get<int>("out_id"), 123);
+  EXPECT_EQ(subtree_bb->get<std::string>("out_name"), "subtree_test");
+  EXPECT_DOUBLE_EQ(subtree_bb->get<double>("out_value"), 1.5);
+}

--- a/tests/plugin_issue953/plugin_issue953.cpp
+++ b/tests/plugin_issue953/plugin_issue953.cpp
@@ -1,0 +1,92 @@
+/**
+ * Plugin for testing Issue #953: convertFromString in plugins
+ *
+ * This plugin defines a custom type (Issue953Type) with its convertFromString
+ * specialization ONLY in this file. The test executable that loads this plugin
+ * does NOT have access to the convertFromString specialization.
+ *
+ * Before the fix: getInput<Issue953Type>() would fail because the executor
+ * couldn't find the convertFromString specialization.
+ *
+ * After the fix: getInput<Issue953Type>() works because the StringConverter
+ * is captured in PortInfo when InputPort<Issue953Type>() is called (here in
+ * the plugin), and getInput() uses that stored converter.
+ */
+
+#include "behaviortree_cpp/bt_factory.h"
+
+// Custom type defined ONLY in the plugin
+struct Issue953Type
+{
+  int id;
+  std::string name;
+  double value;
+};
+
+// convertFromString specialization ONLY in the plugin - not visible to executor
+namespace BT
+{
+template <>
+inline Issue953Type convertFromString(StringView str)
+{
+  // Format: "id;name;value" e.g., "42;test;3.14"
+  const auto parts = BT::splitString(str, ';');
+  if(parts.size() != 3)
+  {
+    throw BT::RuntimeError("Invalid Issue953Type format. Expected: id;name;value");
+  }
+
+  Issue953Type result;
+  result.id = convertFromString<int>(parts[0]);
+  result.name = std::string(parts[1]);
+  result.value = convertFromString<double>(parts[2]);
+  return result;
+}
+}  // namespace BT
+
+// Action node that uses Issue953Type
+class Issue953Action : public BT::SyncActionNode
+{
+public:
+  Issue953Action(const std::string& name, const BT::NodeConfig& config)
+    : BT::SyncActionNode(name, config)
+  {}
+
+  BT::NodeStatus tick() override
+  {
+    // This getInput call relies on the stored StringConverter from PortInfo
+    // because the executor doesn't have the convertFromString specialization
+    auto result = getInput<Issue953Type>("input");
+    if(!result)
+    {
+      std::cerr << "getInput failed: " << result.error() << std::endl;
+      return BT::NodeStatus::FAILURE;
+    }
+
+    const auto& data = result.value();
+
+    // Store results in output ports so the test can verify them
+    setOutput("out_id", data.id);
+    setOutput("out_name", data.name);
+    setOutput("out_value", data.value);
+
+    return BT::NodeStatus::SUCCESS;
+  }
+
+  static BT::PortsList providedPorts()
+  {
+    // When InputPort<Issue953Type>() is called here (in the plugin),
+    // GetAnyFromStringFunctor<Issue953Type>() captures the convertFromString
+    // specialization that IS visible in this compilation unit.
+    return { BT::InputPort<Issue953Type>("input", "Input in format: id;name;value"),
+             BT::OutputPort<int>("out_id", "{out_id}", "Parsed ID"),
+             BT::OutputPort<std::string>("out_name", "{out_name}", "Parsed name"),
+             BT::OutputPort<double>("out_value", "{out_value}", "Parsed value") };
+  }
+};
+
+// Register the node when plugin is loaded
+BT_REGISTER_NODES(factory)
+{
+  factory.registerNodeType<Issue953Action>("Issue953Action");
+}


### PR DESCRIPTION
## Summary

Fixes #953: When a node is loaded as a plugin, the `convertFromString<T>` specialization defined in the plugin is not visible to the main application. This caused `getInput<T>()` to fail.

**Root cause**: `TreeNode::parseString<T>()` directly called `convertFromString<T>()`, which gets compiled in the main application's context - missing the plugin's specialization.

**Solution**: Modified `TreeNode::getInputStamped()` to use the `StringConverter` stored in `PortInfo` (captured when `InputPort<T>()` was called inside the plugin) rather than directly calling `convertFromString<T>()`.

## Changes

- **tree_node.h**: Add `parseStringWithConverter` lambda that checks for stored converter before falling back to `convertFromString<T>()`
- **tests/plugin_issue953/**: New plugin with custom type and converter defined ONLY in the plugin
- **tests/gtest_plugin_issue953.cpp**: 3 test cases proving the fix works:
  - `GetInputUsesStoredConverter`: XML literal value
  - `GetInputFromBlackboardString`: Value from Script node  
  - `GetInputViaSubtreeRemapping`: SubTree port remapping

## Test plan

- [x] All 447 tests pass
- [x] New plugin-based tests verify the fix works across shared library boundaries
- [x] Pre-commit hooks pass (clang-format, codespell)

🤖 Generated with [Claude Code](https://claude.ai/code)