### PR TITLE
Add polymorphic shared_ptr port support (Issue #943)

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -38,6 +38,7 @@ CompileExample("t15_nodes_mocking")
 CompileExample("t16_global_blackboard")
 CompileExample("t17_blackboard_backup")
 CompileExample("t18_waypoints")
+CompileExample("t19_polymorphic_ports")
 
 CompileExample("ex01_wrap_legacy")
 CompileExample("ex02_runtime_ports")

--- a/examples/t19_polymorphic_ports.cpp
+++ b/examples/t19_polymorphic_ports.cpp
@@ -1,0 +1,162 @@
+#include "behaviortree_cpp/bt_factory.h"
+
+using namespace BT;
+
+/* This tutorial shows how to use polymorphic ports.
+ *
+ * When nodes produce and consume shared_ptr<T> via ports,
+ * you may want a node that outputs shared_ptr<Derived> to feed
+ * into a node that expects shared_ptr<Base>.
+ *
+ * By registering the inheritance relationship with
+ * factory.registerPolymorphicCast<Derived, Base>(), the library
+ * handles the upcast automatically — both at tree-creation time
+ * (port type validation) and at runtime (getInput / get).
+ *
+ * Transitive casts are supported: if you register A->B and B->C,
+ * then A->C works automatically.
+ */
+
+//--------------------------------------------------------------
+// A simple class hierarchy
+//--------------------------------------------------------------
+
+class Animal
+{
+public:
+  using Ptr = std::shared_ptr<Animal>;
+  virtual ~Animal() = default;
+
+  virtual std::string name() const
+  {
+    return "Animal";
+  }
+};
+
+class Cat : public Animal
+{
+public:
+  using Ptr = std::shared_ptr<Cat>;
+
+  std::string name() const override
+  {
+    return "Cat";
+  }
+};
+
+class Sphynx : public Cat
+{
+public:
+  using Ptr = std::shared_ptr<Sphynx>;
+
+  std::string name() const override
+  {
+    return "Sphynx";
+  }
+};
+
+//--------------------------------------------------------------
+// Nodes that produce derived types
+//--------------------------------------------------------------
+
+class CreateCat : public SyncActionNode
+{
+public:
+  CreateCat(const std::string& name, const NodeConfig& config)
+    : SyncActionNode(name, config)
+  {}
+
+  NodeStatus tick() override
+  {
+    setOutput("animal", std::make_shared<Cat>());
+    return NodeStatus::SUCCESS;
+  }
+
+  static PortsList providedPorts()
+  {
+    return { OutputPort<Cat::Ptr>("animal") };
+  }
+};
+
+class CreateSphynx : public SyncActionNode
+{
+public:
+  CreateSphynx(const std::string& name, const NodeConfig& config)
+    : SyncActionNode(name, config)
+  {}
+
+  NodeStatus tick() override
+  {
+    setOutput("animal", std::make_shared<Sphynx>());
+    return NodeStatus::SUCCESS;
+  }
+
+  static PortsList providedPorts()
+  {
+    return { OutputPort<Sphynx::Ptr>("animal") };
+  }
+};
+
+//--------------------------------------------------------------
+// A node that consumes the base type
+//--------------------------------------------------------------
+
+class SayHi : public SyncActionNode
+{
+public:
+  SayHi(const std::string& name, const NodeConfig& config) : SyncActionNode(name, config)
+  {}
+
+  NodeStatus tick() override
+  {
+    auto animal = getInput<Animal::Ptr>("animal").value();
+    std::cout << "Hi! I am a " << animal->name() << std::endl;
+    return NodeStatus::SUCCESS;
+  }
+
+  static PortsList providedPorts()
+  {
+    return { InputPort<Animal::Ptr>("animal") };
+  }
+};
+
+//--------------------------------------------------------------
+
+// clang-format off
+static const char* xml_text = R"(
+ <root BTCPP_format="4" >
+   <BehaviorTree ID="MainTree">
+     <Sequence>
+       <CreateCat    animal="{pet}" />
+       <SayHi        animal="{pet}" />
+       <CreateSphynx animal="{pet2}" />
+       <SayHi        animal="{pet2}" />
+     </Sequence>
+   </BehaviorTree>
+ </root>
+)";
+// clang-format on
+
+int main()
+{
+  BehaviorTreeFactory factory;
+
+  // Register the inheritance relationships.
+  // This is what makes Cat::Ptr and Sphynx::Ptr assignable to Animal::Ptr ports.
+  factory.registerPolymorphicCast<Cat, Animal>();
+  factory.registerPolymorphicCast<Sphynx, Cat>();
+
+  factory.registerNodeType<CreateCat>("CreateCat");
+  factory.registerNodeType<CreateSphynx>("CreateSphynx");
+  factory.registerNodeType<SayHi>("SayHi");
+
+  auto tree = factory.createTreeFromText(xml_text);
+  tree.tickWhileRunning();
+
+  /* Expected output:
+   *
+   *   Hi! I am a Cat
+   *   Hi! I am a Sphynx
+   */
+  return 0;
+}

--- a/include/behaviortree_cpp/bt_factory.h
+++ b/include/behaviortree_cpp/bt_factory.h
@@ -17,6 +17,7 @@
 #include "behaviortree_cpp/behavior_tree.h"
 #include "behaviortree_cpp/contrib/json.hpp"
 #include "behaviortree_cpp/contrib/magic_enum.hpp"
+#include "behaviortree_cpp/utils/polymorphic_cast_registry.hpp"
 
 #include <filesystem>
 #include <functional>
@@ -528,6 +529,45 @@ public:
    */
   [[nodiscard]] const std::unordered_map<std::string, SubstitutionRule>&
   substitutionRules() const;
+
+  /**
+   * @brief Register a polymorphic cast relationship between Derived and Base types.
+   *
+   * This enables passing shared_ptr<Derived> to ports expecting shared_ptr<Base>
+   * without type mismatch errors. The relationship is automatically applied
+   * to all trees created from this factory.
+   *
+   * Example:
+   *   factory.registerPolymorphicCast<Cat, Animal>();
+   *   factory.registerPolymorphicCast<Sphynx, Cat>();
+   *
+   * @tparam Derived The derived class (must inherit from Base)
+   * @tparam Base The base class (must be polymorphic)
+   */
+  template <typename Derived, typename Base>
+  void registerPolymorphicCast()
+  {
+    polymorphicCastRegistry().registerCast<Derived, Base>();
+  }
+
+  /**
+   * @brief Access the polymorphic cast registry.
+   *
+   * The registry is shared with all trees created from this factory,
+   * allowing trees to outlive the factory while maintaining access
+   * to polymorphic cast relationships.
+   */
+  [[nodiscard]] PolymorphicCastRegistry& polymorphicCastRegistry();
+  [[nodiscard]] const PolymorphicCastRegistry& polymorphicCastRegistry() const;
+
+  /**
+   * @brief Get a shared pointer to the polymorphic cast registry.
+   *
+   * This allows trees and blackboards to hold a reference to the registry
+   * that outlives the factory.
+   */
+  [[nodiscard]] std::shared_ptr<PolymorphicCastRegistry>
+  polymorphicCastRegistryPtr() const;
 
 private:
   struct PImpl;

--- a/include/behaviortree_cpp/tree_node.h
+++ b/include/behaviortree_cpp/tree_node.h
@@ -591,7 +591,13 @@ inline Expected<Timestamp> TreeNode::getInputStamped(const std::string& key,
         }
         else
         {
-          destination = any_value.cast<T>();
+          auto result =
+              config().blackboard->tryCastWithPolymorphicFallback<T>(&any_value);
+          if(!result)
+          {
+            throw std::runtime_error(result.error());
+          }
+          destination = result.value();
         }
         return Timestamp{ entry->sequence_id, entry->stamp };
       }

--- a/include/behaviortree_cpp/utils/polymorphic_cast_registry.hpp
+++ b/include/behaviortree_cpp/utils/polymorphic_cast_registry.hpp
@@ -1,0 +1,392 @@
+/* Copyright (C) 2022-2025 Davide Faconti -  All Rights Reserved
+*
+*   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+*   to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+*   and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+*   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+*
+*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+*   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include "behaviortree_cpp/contrib/any.hpp"
+#include "behaviortree_cpp/contrib/expected.hpp"
+
+#include <algorithm>
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <shared_mutex>
+#include <typeindex>
+
+namespace BT
+{
+
+/**
+ * @brief Registry for polymorphic shared_ptr cast relationships.
+ *
+ * This enables passing shared_ptr<Derived> to ports expecting shared_ptr<Base>
+ * without breaking ABI compatibility. Users register inheritance relationships
+ * at runtime, and the registry handles upcasting/downcasting transparently.
+ *
+ * This class is typically owned by BehaviorTreeFactory and passed to Blackboard
+ * during tree creation. This avoids global state and makes testing easier.
+ *
+ * Usage with BehaviorTreeFactory:
+ *   BehaviorTreeFactory factory;
+ *   factory.registerPolymorphicCast<Cat, Animal>();
+ *   factory.registerPolymorphicCast<Sphynx, Cat>();
+ *   auto tree = factory.createTreeFromText(xml);
+ */
+class PolymorphicCastRegistry
+{
+public:
+  using CastFunction = std::function<linb::any(const linb::any&)>;
+
+  PolymorphicCastRegistry() = default;
+  ~PolymorphicCastRegistry() = default;
+
+  // Non-copyable, non-movable (contains mutex)
+  PolymorphicCastRegistry(const PolymorphicCastRegistry&) = delete;
+  PolymorphicCastRegistry& operator=(const PolymorphicCastRegistry&) = delete;
+  PolymorphicCastRegistry(PolymorphicCastRegistry&&) = delete;
+  PolymorphicCastRegistry& operator=(PolymorphicCastRegistry&&) = delete;
+
+  /**
+   * @brief Register a Derived -> Base inheritance relationship.
+   *
+   * This enables:
+   * - Upcasting: shared_ptr<Derived> can be retrieved as shared_ptr<Base>
+   * - Downcasting: shared_ptr<Base> can be retrieved as shared_ptr<Derived>
+   *   (via dynamic_pointer_cast, may return nullptr if types don't match)
+   *
+   * @tparam Derived The derived class (must inherit from Base)
+   * @tparam Base The base class (must be polymorphic - have virtual functions)
+   */
+  template <typename Derived, typename Base>
+  void registerCast()
+  {
+    static_assert(std::is_base_of_v<Base, Derived>, "Derived must inherit from Base");
+    static_assert(std::is_polymorphic_v<Base>, "Base must be polymorphic (have virtual "
+                                               "functions)");
+
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+
+    // Register upcast: Derived -> Base
+    auto upcast_key = std::make_pair(std::type_index(typeid(std::shared_ptr<Derived>)),
+                                     std::type_index(typeid(std::shared_ptr<Base>)));
+
+    upcasts_[upcast_key] = [](const linb::any& from) -> linb::any {
+      auto ptr = linb::any_cast<std::shared_ptr<Derived>>(from);
+      return std::static_pointer_cast<Base>(ptr);
+    };
+
+    // Register downcast: Base -> Derived (uses dynamic_pointer_cast)
+    auto downcast_key = std::make_pair(std::type_index(typeid(std::shared_ptr<Base>)),
+                                       std::type_index(typeid(std::shared_ptr<Derived>)));
+
+    downcasts_[downcast_key] = [](const linb::any& from) -> linb::any {
+      auto ptr = linb::any_cast<std::shared_ptr<Base>>(from);
+      auto derived = std::dynamic_pointer_cast<Derived>(ptr);
+      if(!derived)
+      {
+        throw std::bad_cast();
+      }
+      return derived;
+    };
+
+    // Track inheritance relationship for port compatibility checks
+    base_types_[std::type_index(typeid(std::shared_ptr<Derived>))].insert(
+        std::type_index(typeid(std::shared_ptr<Base>)));
+  }
+
+  /**
+   * @brief Check if from_type can be converted to to_type.
+   *
+   * Returns true if:
+   * - from_type == to_type
+   * - from_type is a registered derived type of to_type (upcast)
+   * - to_type is a registered derived type of from_type (downcast)
+   */
+  [[nodiscard]] bool isConvertible(std::type_index from_type,
+                                   std::type_index to_type) const
+  {
+    if(from_type == to_type)
+    {
+      return true;
+    }
+
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+
+    // Check direct upcast
+    auto upcast_key = std::make_pair(from_type, to_type);
+    if(upcasts_.find(upcast_key) != upcasts_.end())
+    {
+      return true;
+    }
+
+    // Check transitive upcast (e.g., Sphynx -> Cat -> Animal)
+    if(canUpcastTransitive(from_type, to_type))
+    {
+      return true;
+    }
+
+    // Check downcast
+    auto downcast_key = std::make_pair(from_type, to_type);
+    if(downcasts_.find(downcast_key) != downcasts_.end())
+    {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * @brief Check if from_type can be UPCAST to to_type (not downcast).
+   *
+   * This is stricter than isConvertible - only allows going from
+   * derived to base, not the reverse.
+   */
+  [[nodiscard]] bool canUpcast(std::type_index from_type, std::type_index to_type) const
+  {
+    if(from_type == to_type)
+    {
+      return true;
+    }
+
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    return canUpcastTransitive(from_type, to_type);
+  }
+
+  /**
+   * @brief Attempt to cast the value to the target type.
+   *
+   * @param from The source any containing a shared_ptr
+   * @param from_type The type_index of the stored type
+   * @param to_type The target type_index
+   * @return The casted any on success, or an error string on failure
+   */
+  [[nodiscard]] nonstd::expected<linb::any, std::string>
+  tryCast(const linb::any& from, std::type_index from_type, std::type_index to_type) const
+  {
+    if(from_type == to_type)
+    {
+      return from;
+    }
+
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+
+    // Try direct upcast
+    auto upcast_key = std::make_pair(from_type, to_type);
+    auto upcast_it = upcasts_.find(upcast_key);
+    if(upcast_it != upcasts_.end())
+    {
+      try
+      {
+        return upcast_it->second(from);
+      }
+      catch(const std::exception& e)
+      {
+        return nonstd::make_unexpected(std::string("Direct upcast failed: ") + e.what());
+      }
+    }
+
+    // Try transitive upcast
+    auto transitive_up = applyTransitiveCasts(from, from_type, to_type, upcasts_, true);
+    if(transitive_up)
+    {
+      return transitive_up;
+    }
+
+    // Try direct downcast
+    auto downcast_key = std::make_pair(from_type, to_type);
+    auto downcast_it = downcasts_.find(downcast_key);
+    if(downcast_it != downcasts_.end())
+    {
+      try
+      {
+        return downcast_it->second(from);
+      }
+      catch(const std::exception& e)
+      {
+        return nonstd::make_unexpected(std::string("Downcast failed "
+                                                   "(dynamic_pointer_cast returned "
+                                                   "null): ") +
+                                       e.what());
+      }
+    }
+
+    // Try transitive downcast
+    auto transitive_down =
+        applyTransitiveCasts(from, to_type, from_type, downcasts_, false);
+    if(transitive_down)
+    {
+      return transitive_down;
+    }
+
+    return nonstd::make_unexpected(std::string("No registered polymorphic conversion "
+                                               "available"));
+  }
+
+  /**
+   * @brief Get all registered base types for a given type.
+   */
+  [[nodiscard]] std::set<std::type_index> getBaseTypes(std::type_index type) const
+  {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    auto it = base_types_.find(type);
+    if(it != base_types_.end())
+    {
+      return it->second;
+    }
+    return {};
+  }
+
+  /**
+   * @brief Clear all registrations (mainly for testing).
+   */
+  void clear()
+  {
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    upcasts_.clear();
+    downcasts_.clear();
+    base_types_.clear();
+  }
+
+private:
+  // Check if we can upcast from_type to to_type through a chain of registered casts
+  [[nodiscard]] bool canUpcastTransitive(std::type_index from_type,
+                                         std::type_index to_type) const
+  {
+    // Depth-first search to find a path from from_type to to_type
+    std::set<std::type_index> visited;
+    std::vector<std::type_index> queue;
+    queue.push_back(from_type);
+
+    while(!queue.empty())
+    {
+      auto current = queue.back();
+      queue.pop_back();
+
+      if(visited.count(current) != 0)
+      {
+        continue;
+      }
+      visited.insert(current);
+
+      auto it = base_types_.find(current);
+      if(it == base_types_.end())
+      {
+        continue;
+      }
+
+      for(const auto& base : it->second)
+      {
+        if(base == to_type)
+        {
+          return true;
+        }
+        queue.push_back(base);
+      }
+    }
+    return false;
+  }
+
+  // Common helper for transitive upcast and downcast.
+  //
+  // Performs depth-first search from dfs_start through base_types_ edges,
+  // looking for dfs_target. When found, reconstructs the path from dfs_target
+  // back to dfs_start. If reverse_path is true, reverses it so casts are applied
+  // in [dfs_start -> dfs_target] order; otherwise applies in traced order.
+  //
+  // For upcast:  dfs_start=from_type, dfs_target=to_type, reverse=true,  map=upcasts_
+  // For downcast: dfs_start=to_type, dfs_target=from_type, reverse=false, map=downcasts_
+  using CastMap = std::map<std::pair<std::type_index, std::type_index>, CastFunction>;
+
+  [[nodiscard]] nonstd::expected<linb::any, std::string> applyTransitiveCasts(
+      const linb::any& from, std::type_index dfs_start, std::type_index dfs_target,
+      const CastMap& cast_map, bool reverse_path) const
+  {
+    // Note: std::type_index has no default constructor, so we can't use operator[]
+    std::map<std::type_index, std::type_index> parent;
+    std::vector<std::type_index> stack;
+    stack.push_back(dfs_start);
+    parent.insert({ dfs_start, dfs_start });
+
+    while(!stack.empty())
+    {
+      auto current = stack.back();
+      stack.pop_back();
+
+      auto it = base_types_.find(current);
+      if(it == base_types_.end())
+      {
+        continue;
+      }
+
+      for(const auto& base : it->second)
+      {
+        if(parent.find(base) != parent.end())
+        {
+          continue;
+        }
+        parent.insert({ base, current });
+        if(base == dfs_target)
+        {
+          // Reconstruct path: trace from dfs_target back to dfs_start
+          std::vector<std::type_index> path;
+          auto node = dfs_target;
+          while(node != dfs_start)
+          {
+            path.push_back(node);
+            node = parent.at(node);
+          }
+          path.push_back(dfs_start);
+
+          if(reverse_path)
+          {
+            std::reverse(path.begin(), path.end());
+          }
+
+          // Apply casts along the path
+          linb::any current_value = from;
+          for(size_t i = 0; i + 1 < path.size(); ++i)
+          {
+            auto cast_key = std::make_pair(path[i], path[i + 1]);
+            auto cast_it = cast_map.find(cast_key);
+            if(cast_it == cast_map.end())
+            {
+              return nonstd::make_unexpected(std::string("Transitive cast: missing step "
+                                                         "in chain"));
+            }
+            try
+            {
+              current_value = cast_it->second(current_value);
+            }
+            catch(const std::exception& e)
+            {
+              return nonstd::make_unexpected(std::string("Transitive cast step "
+                                                         "failed: ") +
+                                             e.what());
+            }
+          }
+          return current_value;
+        }
+        stack.push_back(base);
+      }
+    }
+    return nonstd::make_unexpected(std::string("No transitive path found"));
+  }
+
+  mutable std::shared_mutex mutex_;
+  std::map<std::pair<std::type_index, std::type_index>, CastFunction> upcasts_;
+  std::map<std::pair<std::type_index, std::type_index>, CastFunction> downcasts_;
+  std::map<std::type_index, std::set<std::type_index>> base_types_;
+};
+
+}  // namespace BT

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ set(BT_TESTS
   gtest_while_do_else.cpp
   gtest_interface.cpp
   gtest_simple_string.cpp
+  gtest_polymorphic_ports.cpp
   gtest_plugin_issue953.cpp
 
   script_parser_test.cpp

--- a/tests/gtest_polymorphic_ports.cpp
+++ b/tests/gtest_polymorphic_ports.cpp
@@ -1,0 +1,496 @@
+#include "behaviortree_cpp/bt_factory.h"
+
+#include <gtest/gtest.h>
+
+#include "include/animal_hierarchy_test.h"
+
+using namespace BT;
+
+//-------------------------------------------------------------------
+// Any-level polymorphic cast tests (registry)
+//-------------------------------------------------------------------
+
+TEST(PolymorphicPortTest, AnyCast_SameType)
+{
+  PolymorphicCastRegistry registry;
+  registry.registerCast<Cat, Animal>();
+  registry.registerCast<Dog, Animal>();
+  registry.registerCast<Sphynx, Cat>();
+
+  auto animal = std::make_shared<Animal>();
+  Any any_animal(animal);
+  EXPECT_NO_THROW(auto res = any_animal.cast<Animal::Ptr>());
+  // Downcast should fail (returns error, doesn't throw)
+  EXPECT_FALSE(any_animal.tryCastWithRegistry<Cat::Ptr>(registry).has_value());
+  EXPECT_FALSE(any_animal.tryCastWithRegistry<Sphynx::Ptr>(registry).has_value());
+}
+
+TEST(PolymorphicPortTest, AnyCast_Upcast)
+{
+  PolymorphicCastRegistry registry;
+  registry.registerCast<Cat, Animal>();
+  registry.registerCast<Dog, Animal>();
+  registry.registerCast<Sphynx, Cat>();
+
+  auto cat = std::make_shared<Cat>();
+  Any any_cat(cat);
+  // Same type works
+  EXPECT_NO_THROW(auto res = any_cat.cast<Cat::Ptr>());
+  // Upcast via registry
+  auto result = any_cat.tryCastWithRegistry<Animal::Ptr>(registry);
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value()->name(), "Cat");
+  // Downcast should fail
+  EXPECT_FALSE(any_cat.tryCastWithRegistry<Sphynx::Ptr>(registry).has_value());
+}
+
+TEST(PolymorphicPortTest, AnyCast_TransitiveUpcast)
+{
+  PolymorphicCastRegistry registry;
+  registry.registerCast<Cat, Animal>();
+  registry.registerCast<Dog, Animal>();
+  registry.registerCast<Sphynx, Cat>();
+
+  auto sphynx = std::make_shared<Sphynx>();
+  Any any_sphynx(sphynx);
+  // Same type works
+  EXPECT_NO_THROW(auto res = any_sphynx.cast<Sphynx::Ptr>());
+  // Upcast to Cat
+  auto as_cat = any_sphynx.tryCastWithRegistry<Cat::Ptr>(registry);
+  EXPECT_TRUE(as_cat.has_value());
+  EXPECT_EQ(as_cat.value()->name(), "Sphynx");
+  // Transitive upcast to Animal
+  auto as_animal = any_sphynx.tryCastWithRegistry<Animal::Ptr>(registry);
+  EXPECT_TRUE(as_animal.has_value());
+  EXPECT_EQ(as_animal.value()->name(), "Sphynx");
+}
+
+TEST(PolymorphicPortTest, AnyCast_DowncastWithRuntimeTypeCheck)
+{
+  PolymorphicCastRegistry registry;
+  registry.registerCast<Cat, Animal>();
+  registry.registerCast<Sphynx, Cat>();
+
+  Cat::Ptr cat = std::make_shared<Sphynx>();  // Store Sphynx as Cat
+  Any any_cat(cat);
+  // Same type works
+  EXPECT_NO_THROW(auto res = any_cat.cast<Cat::Ptr>());
+  // Downcast should work because runtime type is Sphynx
+  auto as_sphynx = any_cat.tryCastWithRegistry<Sphynx::Ptr>(registry);
+  EXPECT_TRUE(as_sphynx.has_value());
+  EXPECT_EQ(as_sphynx.value()->name(), "Sphynx");
+}
+
+TEST(PolymorphicPortTest, AnyCast_UnrelatedTypes)
+{
+  PolymorphicCastRegistry registry;
+  registry.registerCast<Cat, Animal>();
+  registry.registerCast<Dog, Animal>();
+
+  auto cat = std::make_shared<Cat>();
+  Any any_cat(cat);
+  EXPECT_FALSE(any_cat.tryCastWithRegistry<Dog::Ptr>(registry).has_value());
+
+  auto dog = std::make_shared<Dog>();
+  Any any_dog(dog);
+  EXPECT_FALSE(any_dog.tryCastWithRegistry<Cat::Ptr>(registry).has_value());
+}
+
+//-------------------------------------------------------------------
+// Test nodes for XML-level polymorphic port testing
+//-------------------------------------------------------------------
+
+class CreateAnimal : public SyncActionNode
+{
+public:
+  CreateAnimal(const std::string& name, const NodeConfig& config)
+    : SyncActionNode(name, config)
+  {}
+
+  NodeStatus tick() override
+  {
+    setOutput("out_animal", std::make_shared<Animal>());
+    return NodeStatus::SUCCESS;
+  }
+
+  static PortsList providedPorts()
+  {
+    return { OutputPort<Animal::Ptr>("out_animal") };
+  }
+};
+
+class CreateCat : public SyncActionNode
+{
+public:
+  CreateCat(const std::string& name, const NodeConfig& config)
+    : SyncActionNode(name, config)
+  {}
+
+  NodeStatus tick() override
+  {
+    setOutput("out_cat", std::make_shared<Cat>());
+    return NodeStatus::SUCCESS;
+  }
+
+  static PortsList providedPorts()
+  {
+    return { OutputPort<Cat::Ptr>("out_cat") };
+  }
+};
+
+class CreateSphynx : public SyncActionNode
+{
+public:
+  CreateSphynx(const std::string& name, const NodeConfig& config)
+    : SyncActionNode(name, config)
+  {}
+
+  NodeStatus tick() override
+  {
+    setOutput("out_sphynx", std::make_shared<Sphynx>());
+    return NodeStatus::SUCCESS;
+  }
+
+  static PortsList providedPorts()
+  {
+    return { OutputPort<Sphynx::Ptr>("out_sphynx") };
+  }
+};
+
+class CreateDog : public SyncActionNode
+{
+public:
+  CreateDog(const std::string& name, const NodeConfig& config)
+    : SyncActionNode(name, config)
+  {}
+
+  NodeStatus tick() override
+  {
+    setOutput("out_dog", std::make_shared<Dog>());
+    return NodeStatus::SUCCESS;
+  }
+
+  static PortsList providedPorts()
+  {
+    return { OutputPort<Dog::Ptr>("out_dog") };
+  }
+};
+
+class CreateCatAsAnimal : public SyncActionNode
+{
+public:
+  CreateCatAsAnimal(const std::string& name, const NodeConfig& config)
+    : SyncActionNode(name, config)
+  {}
+
+  NodeStatus tick() override
+  {
+    setOutput("out_animal", Animal::Ptr(std::make_shared<Cat>()));
+    return NodeStatus::SUCCESS;
+  }
+
+  static PortsList providedPorts()
+  {
+    return { OutputPort<Animal::Ptr>("out_animal") };
+  }
+};
+
+class PrintAnimalName : public SyncActionNode
+{
+public:
+  PrintAnimalName(const std::string& name, const NodeConfig& config)
+    : SyncActionNode(name, config)
+  {}
+
+  NodeStatus tick() override
+  {
+    Animal::Ptr animal;
+    if(!getInput("in_animal", animal) || !animal)
+    {
+      return NodeStatus::FAILURE;
+    }
+    last_name_ = animal->name();
+    return NodeStatus::SUCCESS;
+  }
+
+  static PortsList providedPorts()
+  {
+    return { InputPort<Animal::Ptr>("in_animal") };
+  }
+
+  static std::string last_name_;
+};
+std::string PrintAnimalName::last_name_;
+
+class PrintCatName : public SyncActionNode
+{
+public:
+  PrintCatName(const std::string& name, const NodeConfig& config)
+    : SyncActionNode(name, config)
+  {}
+
+  NodeStatus tick() override
+  {
+    Cat::Ptr cat;
+    if(!getInput("in_cat", cat) || !cat)
+    {
+      return NodeStatus::FAILURE;
+    }
+    last_name_ = cat->name();
+    return NodeStatus::SUCCESS;
+  }
+
+  static PortsList providedPorts()
+  {
+    return { InputPort<Cat::Ptr>("in_cat") };
+  }
+
+  static std::string last_name_;
+};
+std::string PrintCatName::last_name_;
+
+class PrintDogName : public SyncActionNode
+{
+public:
+  PrintDogName(const std::string& name, const NodeConfig& config)
+    : SyncActionNode(name, config)
+  {}
+
+  NodeStatus tick() override
+  {
+    Dog::Ptr dog;
+    if(!getInput("in_dog", dog) || !dog)
+    {
+      return NodeStatus::FAILURE;
+    }
+    last_name_ = dog->name();
+    return NodeStatus::SUCCESS;
+  }
+
+  static PortsList providedPorts()
+  {
+    return { InputPort<Dog::Ptr>("in_dog") };
+  }
+
+  static std::string last_name_;
+};
+std::string PrintDogName::last_name_;
+
+//-------------------------------------------------------------------
+// Blackboard-level polymorphic get/set tests
+//-------------------------------------------------------------------
+
+namespace
+{
+Blackboard::Ptr createBlackboardWithRegistry()
+{
+  auto bb = Blackboard::create();
+  auto registry = std::make_shared<PolymorphicCastRegistry>();
+  registry->registerCast<Cat, Animal>();
+  registry->registerCast<Dog, Animal>();
+  registry->registerCast<Sphynx, Cat>();
+  bb->setPolymorphicCastRegistry(registry);
+  return bb;
+}
+}  // namespace
+
+TEST(PolymorphicPortTest, Blackboard_UpcastAndDowncast)
+{
+  auto bb = createBlackboardWithRegistry();
+
+  // Store a Cat, retrieve as Animal (upcast)
+  auto cat = std::make_shared<Cat>();
+  bb->set("pet", cat);
+
+  Animal::Ptr animal;
+  ASSERT_TRUE(bb->get("pet", animal));
+  ASSERT_EQ(animal->name(), "Cat");
+
+  // Can still get as Cat
+  Cat::Ptr retrieved_cat;
+  ASSERT_TRUE(bb->get("pet", retrieved_cat));
+  ASSERT_EQ(retrieved_cat->name(), "Cat");
+
+  // Cannot get as Sphynx (invalid downcast)
+  Sphynx::Ptr sphynx;
+  ASSERT_ANY_THROW((void)bb->get("pet", sphynx));
+}
+
+TEST(PolymorphicPortTest, Blackboard_TransitiveUpcast)
+{
+  auto bb = createBlackboardWithRegistry();
+
+  auto sphynx = std::make_shared<Sphynx>();
+  bb->set("pet", sphynx);
+
+  // Can get as Animal (transitive upcast through Cat)
+  Animal::Ptr animal;
+  ASSERT_TRUE(bb->get("pet", animal));
+  ASSERT_EQ(animal->name(), "Sphynx");
+
+  // Can get as Cat (direct upcast)
+  Cat::Ptr cat;
+  ASSERT_TRUE(bb->get("pet", cat));
+  ASSERT_EQ(cat->name(), "Sphynx");
+
+  // Can get as Sphynx (same type)
+  Sphynx::Ptr retrieved_sphynx;
+  ASSERT_TRUE(bb->get("pet", retrieved_sphynx));
+  ASSERT_EQ(retrieved_sphynx->name(), "Sphynx");
+}
+
+//-------------------------------------------------------------------
+// XML tree-level polymorphic port tests
+//-------------------------------------------------------------------
+
+TEST(PolymorphicPortTest, XML_ValidUpcast)
+{
+  std::string xml_txt = R"(
+  <root BTCPP_format="4" >
+    <BehaviorTree ID="Main">
+      <Sequence>
+        <CreateCat out_cat="{pet}" />
+        <PrintCatName in_cat="{pet}" />
+        <PrintAnimalName in_animal="{pet}" />
+      </Sequence>
+    </BehaviorTree>
+  </root>)";
+
+  BehaviorTreeFactory factory;
+  RegisterAnimalHierarchy(factory);
+  factory.registerNodeType<CreateCat>("CreateCat");
+  factory.registerNodeType<PrintCatName>("PrintCatName");
+  factory.registerNodeType<PrintAnimalName>("PrintAnimalName");
+
+  auto tree = factory.createTreeFromText(xml_txt);
+  NodeStatus status = tree.tickWhileRunning();
+
+  ASSERT_EQ(status, NodeStatus::SUCCESS);
+  ASSERT_EQ(PrintCatName::last_name_, "Cat");
+  ASSERT_EQ(PrintAnimalName::last_name_, "Cat");
+}
+
+TEST(PolymorphicPortTest, XML_TransitiveUpcast)
+{
+  std::string xml_txt = R"(
+  <root BTCPP_format="4" >
+    <BehaviorTree ID="Main">
+      <Sequence>
+        <CreateSphynx out_sphynx="{pet}" />
+        <PrintAnimalName in_animal="{pet}" />
+      </Sequence>
+    </BehaviorTree>
+  </root>)";
+
+  BehaviorTreeFactory factory;
+  RegisterAnimalHierarchy(factory);
+  factory.registerNodeType<CreateSphynx>("CreateSphynx");
+  factory.registerNodeType<PrintAnimalName>("PrintAnimalName");
+
+  auto tree = factory.createTreeFromText(xml_txt);
+  NodeStatus status = tree.tickWhileRunning();
+
+  ASSERT_EQ(status, NodeStatus::SUCCESS);
+  ASSERT_EQ(PrintAnimalName::last_name_, "Sphynx");
+}
+
+TEST(PolymorphicPortTest, XML_InoutRejectsTypeMismatch)
+{
+  class UpdateAnimal : public SyncActionNode
+  {
+  public:
+    UpdateAnimal(const std::string& name, const NodeConfig& config)
+      : SyncActionNode(name, config)
+    {}
+    NodeStatus tick() override
+    {
+      return NodeStatus::SUCCESS;
+    }
+    static PortsList providedPorts()
+    {
+      return { BidirectionalPort<Animal::Ptr>("animal") };
+    }
+  };
+
+  std::string xml_txt = R"(
+  <root BTCPP_format="4" >
+    <BehaviorTree ID="Main">
+      <Sequence>
+        <CreateCat out_cat="{pet}" />
+        <UpdateAnimal animal="{pet}" />
+      </Sequence>
+    </BehaviorTree>
+  </root>)";
+
+  BehaviorTreeFactory factory;
+  RegisterAnimalHierarchy(factory);
+  factory.registerNodeType<CreateCat>("CreateCat");
+  factory.registerNodeType<UpdateAnimal>("UpdateAnimal");
+
+  ASSERT_ANY_THROW((void)factory.createTreeFromText(xml_txt));
+}
+
+TEST(PolymorphicPortTest, XML_InvalidConnection_UnrelatedTypes)
+{
+  std::string xml_txt = R"(
+  <root BTCPP_format="4" >
+    <BehaviorTree ID="Main">
+      <Sequence>
+        <CreateCat out_cat="{pet}" />
+        <PrintDogName in_dog="{pet}" />
+      </Sequence>
+    </BehaviorTree>
+  </root>)";
+
+  BehaviorTreeFactory factory;
+  factory.registerNodeType<CreateCat>("CreateCat");
+  factory.registerNodeType<PrintDogName>("PrintDogName");
+
+  ASSERT_ANY_THROW((void)factory.createTreeFromText(xml_txt));
+}
+
+TEST(PolymorphicPortTest, XML_DowncastSucceedsAtRuntime)
+{
+  std::string xml_txt = R"(
+  <root BTCPP_format="4" >
+    <BehaviorTree ID="Main">
+      <Sequence>
+        <CreateCatAsAnimal out_animal="{pet}" />
+        <PrintCatName in_cat="{pet}" />
+      </Sequence>
+    </BehaviorTree>
+  </root>)";
+
+  BehaviorTreeFactory factory;
+  RegisterAnimalHierarchy(factory);
+  factory.registerNodeType<CreateCatAsAnimal>("CreateCatAsAnimal");
+  factory.registerNodeType<PrintCatName>("PrintCatName");
+
+  auto tree = factory.createTreeFromText(xml_txt);
+  NodeStatus status = tree.tickWhileRunning();
+
+  ASSERT_EQ(status, NodeStatus::SUCCESS);
+  ASSERT_EQ(PrintCatName::last_name_, "Cat");
+}
+
+TEST(PolymorphicPortTest, XML_DowncastFailsAtRuntime)
+{
+  std::string xml_txt = R"(
+  <root BTCPP_format="4" >
+    <BehaviorTree ID="Main">
+      <Sequence>
+        <CreateAnimal out_animal="{pet}" />
+        <PrintCatName in_cat="{pet}" />
+      </Sequence>
+    </BehaviorTree>
+  </root>)";
+
+  BehaviorTreeFactory factory;
+  RegisterAnimalHierarchy(factory);
+  factory.registerNodeType<CreateAnimal>("CreateAnimal");
+  factory.registerNodeType<PrintCatName>("PrintCatName");
+
+  auto tree = factory.createTreeFromText(xml_txt);
+  // Runtime should fail (actual type is Animal, not Cat)
+  ASSERT_EQ(tree.tickWhileRunning(), NodeStatus::FAILURE);
+}

--- a/tests/include/animal_hierarchy_test.h
+++ b/tests/include/animal_hierarchy_test.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+// Animal hierarchy for testing polymorphic port connections
+//
+//         Animal
+//        /      \
+//      Cat      Dog
+//       |
+//    Sphynx
+
+class Animal
+{
+public:
+  using Ptr = std::shared_ptr<Animal>;
+
+  Animal() = default;
+  virtual ~Animal() = default;
+  Animal(const Animal&) = default;
+  Animal& operator=(const Animal&) = default;
+  Animal(Animal&&) = default;
+  Animal& operator=(Animal&&) = default;
+
+  virtual std::string name() const
+  {
+    return "Animal";
+  }
+};
+
+class Cat : public Animal
+{
+public:
+  using Ptr = std::shared_ptr<Cat>;
+
+  std::string name() const override
+  {
+    return "Cat";
+  }
+
+  void meow() const
+  {}
+};
+
+class Dog : public Animal
+{
+public:
+  using Ptr = std::shared_ptr<Dog>;
+
+  std::string name() const override
+  {
+    return "Dog";
+  }
+
+  void bark() const
+  {}
+};
+
+class Sphynx : public Cat
+{
+public:
+  using Ptr = std::shared_ptr<Sphynx>;
+
+  std::string name() const override
+  {
+    return "Sphynx";
+  }
+};
+
+// Helper to register the animal hierarchy with a factory
+// Usage: RegisterAnimalHierarchy(factory);
+#include "behaviortree_cpp/bt_factory.h"
+inline void RegisterAnimalHierarchy(BT::BehaviorTreeFactory& factory)
+{
+  factory.registerPolymorphicCast<Cat, Animal>();
+  factory.registerPolymorphicCast<Dog, Animal>();
+  factory.registerPolymorphicCast<Sphynx, Cat>();
+}


### PR DESCRIPTION
Enable passing shared_ptr<Derived> to ports expecting shared_ptr<Base> while preserving ABI and API compatibility.

Implementation:
- Add PolymorphicCastRegistry class for runtime cast registration
- Store registry in BehaviorTreeFactory via PImpl (ABI-safe)
- Propagate registry to blackboards via shared_ptr (tree outlives factory)
- Add polymorphic cast fallback in Blackboard::get() and TreeNode::getInputStamped()
- Add port type validation with polymorphic awareness in XML parser

API:
- factory.registerPolymorphicCast<Derived, Base>() to register relationships
- Supports transitive upcasts (Sphynx -> Cat -> Animal)
- Compile-time port type checking still catches invalid connections

<!--
## Instructions

- Unless your code is self explaining, add comments.
- Consider if your proposed changes introduces API, ABI, back-compatibility or behavioral changes.
- If your code is fixing a bug, please create a unit test to reproduce the bug, i.e. a test that fails before the fix and pass after the fix.
- You use [pre-commit](https://pre-commit.com/) to apply automatically all the required linting rules (clang-format in particular).
- You should also execute the script `./run_clang_tidy.sh` and correct all the warnings.

Please read the CONTRIBUTORS_GUIDE.md file for details and instructions.
-->
