### PR TITLE
Require C++17 to match ament_index_cpp 1.8.3+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@ project(behaviortree_cpp_v3)
 set(CMAKE_CONFIG_PATH ${CMAKE_MODULE_PATH}  "${CMAKE_CURRENT_LIST_DIR}/cmake")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CONFIG_PATH}")
 
-#---- Enable C++14 ----
-set(CMAKE_CXX_STANDARD 14)
+#---- Enable C++17 ----
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(MSVC)


### PR DESCRIPTION
This PR tries to fix the [current regression in Jazzy](https://github.com/ros2/ros2/releases/tag/release-jazzy-20240523https://github.com/ros2/ros2/releases/tag/release-jazzy-20240523) by  setting `CMAKE_CXX_STANDARD 17` to aligning `behaviortree_cpp_v3` with `ament_index_cpp`.

Why: 

`behaviortree_cpp_v3` is failing to build against `ament_index_cpp 1.8.3` because `get_package_share_directory.hpp` now unconditionally includes `<filesystem>`, which requires `C++17`. This package was explicitly setting `CMAKE_CXX_STANDARD 14`, which caused the compilation to fail when including that header.

The breakage should not be blamed on the `ament_index_cpp` since the package has required `C++17` since version `1.7.0` (commit https://github.com/ament/ament_index/commit/43e7b007b787fe7cd4d5674c5e722987544f79f1, Aug 2023): and [Jazzy was released 2024-05-23](https://github.com/ros2/ros2/releases/tag/release-jazzy-20240523).

AFAIK there shouldn't be any downstream impact out of this change since `behaviortree_cpp_v3` does not export its C++ standard requirement to consumers