### PR TITLE
Add `Tree::wakeUpSignal()` getter

### DIFF
--- a/include/behaviortree_cpp/bt_factory.h
+++ b/include/behaviortree_cpp/bt_factory.h
@@ -127,7 +127,7 @@ public:
   /// WakeUpSignal so it can check for early wake-up.
   /// Return true if woken up before the timeout, false if the full duration elapsed.
   using SleepOverrideFunc =
-    std::function<bool(std::chrono::system_clock::duration, WakeUpSignal&)>;
+      std::function<bool(std::chrono::system_clock::duration, WakeUpSignal&)>;
 
   /**
     * @brief Sleep for a certain amount of time. This sleep could be interrupted by the methods

--- a/include/behaviortree_cpp/bt_factory.h
+++ b/include/behaviortree_cpp/bt_factory.h
@@ -122,6 +122,13 @@ public:
 
   [[nodiscard]] TreeNode* rootNode() const;
 
+  /// Function signature for a custom sleep override.
+  /// The function receives the desired sleep duration and a reference to the
+  /// WakeUpSignal so it can check for early wake-up.
+  /// Return true if woken up before the timeout, false if the full duration elapsed.
+  using SleepOverrideFunc =
+    std::function<bool(std::chrono::system_clock::duration, WakeUpSignal&)>;
+
   /**
     * @brief Sleep for a certain amount of time. This sleep could be interrupted by the methods
     * TreeNode::emitWakeUpSignal() or Tree::emitWakeUpSignal()
@@ -136,6 +143,14 @@ public:
    * @brief Wake up the tree. This will interrupt the sleep() method.
    */
   void emitWakeUpSignal();
+
+  /**
+   * @brief Set a custom sleep override function. When set, Tree::sleep()
+   * will delegate to this function instead of using the default
+   * WakeUpSignal::waitFor(). This allows integrating with external clock
+   * sources (e.g. ROS sim time) while preserving wake-up signal support.
+   */
+  void setSleepOverride(SleepOverrideFunc func);
 
   ~Tree();
 
@@ -196,6 +211,7 @@ private:
   friend class BehaviorTreeFactory;
 
   std::shared_ptr<WakeUpSignal> wake_up_;
+  SleepOverrideFunc sleep_override_;
 
   enum TickOption
   {

--- a/include/behaviortree_cpp/bt_factory.h
+++ b/include/behaviortree_cpp/bt_factory.h
@@ -122,13 +122,6 @@ public:
 
   [[nodiscard]] TreeNode* rootNode() const;
 
-  /// Function signature for a custom sleep override.
-  /// The function receives the desired sleep duration and a reference to the
-  /// WakeUpSignal so it can check for early wake-up.
-  /// Return true if woken up before the timeout, false if the full duration elapsed.
-  using SleepOverrideFunc =
-      std::function<bool(std::chrono::system_clock::duration, WakeUpSignal&)>;
-
   /**
     * @brief Sleep for a certain amount of time. This sleep could be interrupted by the methods
     * TreeNode::emitWakeUpSignal() or Tree::emitWakeUpSignal()
@@ -145,12 +138,12 @@ public:
   void emitWakeUpSignal();
 
   /**
-   * @brief Set a custom sleep override function. When set, Tree::sleep()
-   * will delegate to this function instead of using the default
-   * WakeUpSignal::waitFor(). This allows integrating with external clock
-   * sources (e.g. ROS sim time) while preserving wake-up signal support.
+   * @brief Returns the shared WakeUpSignal used by this tree.
+   * This can be used to check for preemption externally, e.g. when
+   * implementing custom sleep logic with a different clock source.
+   * Returns nullptr if the tree has not been initialized yet.
    */
-  void setSleepOverride(SleepOverrideFunc func);
+  [[nodiscard]] std::shared_ptr<WakeUpSignal> wakeUpSignal() const;
 
   ~Tree();
 
@@ -211,7 +204,6 @@ private:
   friend class BehaviorTreeFactory;
 
   std::shared_ptr<WakeUpSignal> wake_up_;
-  SleepOverrideFunc sleep_override_;
 
   enum TickOption
   {

--- a/src/bt_factory.cpp
+++ b/src/bt_factory.cpp
@@ -655,6 +655,10 @@ TreeNode* Tree::rootNode() const
 
 bool Tree::sleep(std::chrono::system_clock::duration timeout)
 {
+  if(sleep_override_)
+  {
+    return sleep_override_(timeout, *wake_up_);
+  }
   return wake_up_->waitFor(
       std::chrono::duration_cast<std::chrono::milliseconds>(timeout));
 }
@@ -662,6 +666,11 @@ bool Tree::sleep(std::chrono::system_clock::duration timeout)
 void Tree::emitWakeUpSignal()
 {
   wake_up_->emitSignal();
+}
+
+void Tree::setSleepOverride(SleepOverrideFunc func)
+{
+  sleep_override_ = std::move(func);
 }
 
 Tree::~Tree()

--- a/src/bt_factory.cpp
+++ b/src/bt_factory.cpp
@@ -655,10 +655,6 @@ TreeNode* Tree::rootNode() const
 
 bool Tree::sleep(std::chrono::system_clock::duration timeout)
 {
-  if(sleep_override_)
-  {
-    return sleep_override_(timeout, *wake_up_);
-  }
   return wake_up_->waitFor(
       std::chrono::duration_cast<std::chrono::milliseconds>(timeout));
 }
@@ -668,9 +664,9 @@ void Tree::emitWakeUpSignal()
   wake_up_->emitSignal();
 }
 
-void Tree::setSleepOverride(SleepOverrideFunc func)
+std::shared_ptr<WakeUpSignal> Tree::wakeUpSignal() const
 {
-  sleep_override_ = std::move(func);
+  return wake_up_;
 }
 
 Tree::~Tree()


### PR DESCRIPTION
## Problem

`Tree::sleep()` uses `WakeUpSignal::waitFor()`, which internally calls `std::condition_variable::wait_for()` — this always measures time against `steady_clock` (wall time). When using a simulated clock that runs faster or slower than real time (e.g., ROS 2's `/clock` topic with `use_sim_time`), the tree tick rate doesn't scale with the simulation. At 10x sim speed, a 100ms loop timeout still blocks 100ms real time, so the tree ticks 10x too slowly relative to the simulated world.

C++ provides no mechanism to make `condition_variable` wait on a custom clock, so any solution requires polling.

## Solution

Add `Tree::wakeUpSignal()` — a simple getter that returns the tree's shared `WakeUpSignal`. This allows frameworks to implement their own clock-aware sleep logic externally while still being able to check for wake-up signals (preemption).

For example, in ROS 2 (Nav2), the between-tick sleep loop can poll the ROS clock for the deadline while doing short `waitFor(1ms)` calls to stay responsive to preemption:

```cpp
auto wake_up = tree->wakeUpSignal();
while (ros_clock->now() < deadline) {
  if (wake_up->waitFor(std::chrono::milliseconds(1)))
    return true;  // woken up early
}
```
