### PR TITLE
Rename header guard for shared_library.h

### DIFF
--- a/include/behaviortree_cpp/utils/shared_library.h
+++ b/include/behaviortree_cpp/utils/shared_library.h
@@ -35,8 +35,8 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-#ifndef Foundation_SharedLibrary_INCLUDED
-#define Foundation_SharedLibrary_INCLUDED
+#ifndef BT_Foundation_SharedLibrary_INCLUDED
+#define BT_Foundation_SharedLibrary_INCLUDED
 
 #include "platform.hpp"
 
@@ -143,4 +143,4 @@ private:
 
 }  // namespace BT
 
-#endif  // Foundation_SharedLibrary_INCLUDED
+#endif  // BT_Foundation_SharedLibrary_INCLUDED


### PR DESCRIPTION
<!--
## Instructions

- Unless your code is self explaining, add comments.
- Consider if your proposed changes introduces API, ABI, back-compatibility or behavioral changes.
- If your code is fixing a bug, please create a unit test to reproduce the bug, i.e. a test that fails before the fix and pass after the fix.
- You use [pre-commit](https://pre-commit.com/) to apply automatically all the required linting rules (clang-format in particular).
- You should also execute the script `./run_clang_tidy.sh` and correct all the warnings.

Please read the CONTRIBUTORS_GUIDE.md file for details and instructions.
-->
This cause conflict when I use BTC++ and Poco in the same project