### PR TITLE
Remove tinyxml2 vendor on rolling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ if ( ament_cmake_FOUND )
     message(STATUS "------------------------------------------")
     include(cmake/ament_build.cmake)
 
-    find_package(tinyxml2_vendor REQUIRED)
+    find_package(tinyxml2_vendor QUIET)
     find_package(TinyXML2 REQUIRED)
 else()
     message(STATUS "------------------------------------------")

--- a/package.xml
+++ b/package.xml
@@ -22,8 +22,8 @@
 
   <depend>libsqlite3-dev</depend>
   <depend>libzmq3-dev</depend>
-  <depend>tinyxml2</depend>
-  <depend>tinyxml2_vendor</depend>
+  <depend condition="$ROS_DISTRO != humble and $ROS_DISTRO != jazzy and $ROS_DISTRO != kilted">tinyxml2</depend>
+  <depend condition="$ROS_DISTRO == humble or $ROS_DISTRO == jazzy or $ROS_DISTRO == kilted">tinyxml2_vendor</depend>
 
   <test_depend >ament_cmake_gtest</test_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -22,7 +22,9 @@
 
   <depend>libsqlite3-dev</depend>
   <depend>libzmq3-dev</depend>
-  <depend condition="$ROS_DISTRO != humble and $ROS_DISTRO != jazzy and $ROS_DISTRO != kilted">tinyxml2</depend>
+  <depend>tinyxml2</depend>
+  <!-- tinyxml2_vendor is deprecated and was removed from Rolling (gone in Lyrical);
+       keep it only on the distros that still ship it -->
   <depend condition="$ROS_DISTRO == humble or $ROS_DISTRO == jazzy or $ROS_DISTRO == kilted">tinyxml2_vendor</depend>
 
   <test_depend >ament_cmake_gtest</test_depend>


### PR DESCRIPTION
In Nav2, we are building BT.CPP from source temporarily, however, we are failing to build now:

```
#20 2.012 Get:20 http://archive.ubuntu.com/ubuntu noble-backports/main amd64 Packages [49.0 kB]
#20 2.013 Get:21 http://archive.ubuntu.com/ubuntu noble-backports/multiverse amd64 Packages [671 B]
#20 2.013 Get:22 http://archive.ubuntu.com/ubuntu noble-backports/universe amd64 Packages [35.6 kB]
#20 3.087 Fetched 41.5 MB in 3s (14.2 MB/s)
#20 3.087 Reading package lists...
#20 4.120 /usr/bin/rosdep:6: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
#20 4.120   from pkg_resources import load_entry_point
#20 5.248 ERROR: the following packages/stacks could not have their rosdep keys resolved
#20 5.248 to system dependencies:
#20 5.248 behaviortree_cpp: No definition of [tinyxml2_vendor] for OS version [noble]
#20 ERROR: process "/bin/sh -c . /opt/ros/$ROS_DISTRO/setup.sh &&     apt-get update && rosdep install -q -y       --from-paths src       --skip-keys \"         slam_toolbox         \"       --ignore-src     && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 1
------
 > [builder  6/11] RUN . /opt/ros/rolling/setup.sh &&     apt-get update && rosdep install -q -y       --from-paths src       --skip-keys "         slam_toolbox         "       --ignore-src     && rm -rf /var/lib/apt/lists/*:
2.012 Get:19 http://archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Packages [54.1 kB]
2.012 Get:20 http://archive.ubuntu.com/ubuntu noble-backports/main amd64 Packages [49.0 kB]
2.013 Get:21 http://archive.ubuntu.com/ubuntu noble-backports/multiverse amd64 Packages [671 B]
2.013 Get:22 http://archive.ubuntu.com/ubuntu noble-backports/universe amd64 Packages [35.6 kB]

4.120 /usr/bin/rosdep:6: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
4.120   from pkg_resources import load_entry_point
5.248 ERROR: the following packages/stacks could not have their rosdep keys resolved
5.248 to system dependencies:
5.248 behaviortree_cpp: No definition of [tinyxml2_vendor] for OS version [noble]
------
```

I believe this is because tinyxml2_vendor is deprecated and removed on rolling, so I am removing this in rolling.

ref: https://github.com/open-planning/roboplan/blob/6987faf083d5b097b4251f8f698a1a7832c3ac86/roboplan/package.xml#L15-L16