### PR TITLE
Fix LoopNode does not reload dynamic vector input on second execution

### DIFF
--- a/include/behaviortree_cpp/decorators/loop_node.h
+++ b/include/behaviortree_cpp/decorators/loop_node.h
@@ -59,6 +59,8 @@ public:
     if(status() == NodeStatus::IDLE)
     {
       child_running_ = false;
+      current_queue_.reset();
+
       // special case: the port contains a string that was converted to SharedQueue<T>
       if(static_queue_)
       {

--- a/tests/gtest_loop.cpp
+++ b/tests/gtest_loop.cpp
@@ -410,6 +410,42 @@ TEST(LoopNode, RestartAfterCompletion)
   ASSERT_EQ(tick_count, 3);  // Should iterate over queue again
 }
 
+TEST(LoopNode, RestartAfterCompletion_VectorFromBlackboard)
+{
+  BehaviorTreeFactory factory;
+
+  int tick_count = 0;
+  factory.registerSimpleAction("CountTicks", [&tick_count](TreeNode&) {
+    tick_count++;
+    return NodeStatus::SUCCESS;
+  });
+
+  const std::string xml_text = R"(
+    <root BTCPP_format="4">
+       <BehaviorTree>
+          <LoopInt queue="{my_vector}" value="{val}">
+            <CountTicks/>
+          </LoopInt>
+       </BehaviorTree>
+    </root>)";
+
+  auto tree = factory.createTreeFromText(xml_text);
+  tree.rootBlackboard()->set("my_vector", std::vector{ 1, 2, 3 });
+
+  // First execution
+  auto status = tree.tickWhileRunning();
+  ASSERT_EQ(status, NodeStatus::SUCCESS);
+  ASSERT_EQ(tick_count, 3);
+
+  // Reset and execute again
+  tree.haltTree();
+  tick_count = 0;
+  tree.rootBlackboard()->set("my_vector", std::vector{ 1, 2, 3 });
+  status = tree.tickWhileRunning();
+  ASSERT_EQ(status, NodeStatus::SUCCESS);
+  ASSERT_EQ(tick_count, 3);  // Should iterate over vector again
+}
+
 // ============ convertFromString tests for SharedQueue ============
 
 TEST(LoopNode, ConvertFromString_Int)


### PR DESCRIPTION
I've implemented the suggestion from https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1124.

This seems to have fixed the issue I had with LoopNode not reloading the input vector on second execution. I've also added a unittest to prevent this issue in the future.