### PR TITLE
Fix -Wfree-nonheap-object and -Wunused-result

### DIFF
--- a/include/behaviortree_cpp/utils/safe_any.hpp
+++ b/include/behaviortree_cpp/utils/safe_any.hpp
@@ -560,7 +560,7 @@ inline nonstd::expected<T, std::string> Any::tryCast() const
 
   if(auto res = convert<T>())
   {
-    return res.value();
+    return std::move(res.value());
   }
   else
   {

--- a/tests/gtest_factory.cpp
+++ b/tests/gtest_factory.cpp
@@ -112,7 +112,7 @@ const char* xml_text_subtree_part2 = R"(
 TEST(BehaviorTreeFactory, NotRegisteredNode)
 {
   BehaviorTreeFactory factory;
-  ASSERT_ANY_THROW(factory.createTreeFromText(xml_text));
+  ASSERT_ANY_THROW((void)factory.createTreeFromText(xml_text));
   ASSERT_ANY_THROW(std::make_shared<BT::Tree>(factory.createTreeFromText(xml_text)));
 }
 
@@ -623,7 +623,7 @@ TEST(BehaviorTreeFactory, MalformedXML_InvalidRoot)
 {
   // XML that is not valid XML at all
   BehaviorTreeFactory factory;
-  EXPECT_ANY_THROW(factory.createTreeFromText("<not valid xml!!!"));
+  EXPECT_ANY_THROW((void)factory.createTreeFromText("<not valid xml!!!"));
 }
 
 TEST(BehaviorTreeFactory, MalformedXML_MissingRootElement)
@@ -637,7 +637,7 @@ TEST(BehaviorTreeFactory, MalformedXML_MissingRootElement)
   </something>)";
 
   BehaviorTreeFactory factory;
-  EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
+  EXPECT_THROW((void)factory.createTreeFromText(xml), RuntimeError);
 }
 
 TEST(BehaviorTreeFactory, MalformedXML_EmptyBehaviorTree)
@@ -650,7 +650,7 @@ TEST(BehaviorTreeFactory, MalformedXML_EmptyBehaviorTree)
   </root>)";
 
   BehaviorTreeFactory factory;
-  EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
+  EXPECT_THROW((void)factory.createTreeFromText(xml), RuntimeError);
 }
 
 TEST(BehaviorTreeFactory, MalformedXML_EmptyBehaviorTreeID)
@@ -667,7 +667,7 @@ TEST(BehaviorTreeFactory, MalformedXML_EmptyBehaviorTreeID)
   </root>)";
 
   BehaviorTreeFactory factory;
-  EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
+  EXPECT_THROW((void)factory.createTreeFromText(xml), RuntimeError);
 }
 
 TEST(BehaviorTreeFactory, MalformedXML_MissingBehaviorTreeID)
@@ -684,7 +684,7 @@ TEST(BehaviorTreeFactory, MalformedXML_MissingBehaviorTreeID)
   </root>)";
 
   BehaviorTreeFactory factory;
-  EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
+  EXPECT_THROW((void)factory.createTreeFromText(xml), RuntimeError);
 }
 
 TEST(BehaviorTreeFactory, MalformedXML_DeeplyNestedElements)
@@ -706,7 +706,7 @@ TEST(BehaviorTreeFactory, MalformedXML_DeeplyNestedElements)
   xml += "</BehaviorTree></root>";
 
   BehaviorTreeFactory factory;
-  EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
+  EXPECT_THROW((void)factory.createTreeFromText(xml), RuntimeError);
 }
 
 TEST(BehaviorTreeFactory, MalformedXML_ModerateNestingIsOK)
@@ -727,7 +727,7 @@ TEST(BehaviorTreeFactory, MalformedXML_ModerateNestingIsOK)
 
   BehaviorTreeFactory factory;
   // Should not throw
-  EXPECT_NO_THROW(factory.createTreeFromText(xml));
+  EXPECT_NO_THROW((void)factory.createTreeFromText(xml));
 }
 
 TEST(BehaviorTreeFactory, MalformedXML_MultipleBTChildElements)
@@ -742,14 +742,14 @@ TEST(BehaviorTreeFactory, MalformedXML_MultipleBTChildElements)
   </root>)";
 
   BehaviorTreeFactory factory;
-  EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
+  EXPECT_THROW((void)factory.createTreeFromText(xml), RuntimeError);
 }
 
 TEST(BehaviorTreeFactory, MalformedXML_CompletelyEmpty)
 {
   // Completely empty string
   BehaviorTreeFactory factory;
-  EXPECT_ANY_THROW(factory.createTreeFromText(""));
+  EXPECT_ANY_THROW((void)factory.createTreeFromText(""));
 }
 
 TEST(BehaviorTreeFactory, MalformedXML_EmptyRoot)
@@ -761,7 +761,7 @@ TEST(BehaviorTreeFactory, MalformedXML_EmptyRoot)
   // No BehaviorTree elements: registering succeeds but creating
   // a tree should fail because there is nothing to instantiate.
   factory.registerBehaviorTreeFromText(xml);
-  EXPECT_ANY_THROW(factory.createTree("MainTree"));
+  EXPECT_ANY_THROW((void)factory.createTree("MainTree"));
 }
 
 TEST(BehaviorTreeFactory, MalformedXML_UnknownNodeType)
@@ -775,5 +775,5 @@ TEST(BehaviorTreeFactory, MalformedXML_UnknownNodeType)
   </root>)";
 
   BehaviorTreeFactory factory;
-  EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
+  EXPECT_THROW((void)factory.createTreeFromText(xml), RuntimeError);
 }

--- a/tests/gtest_name_validation.cpp
+++ b/tests/gtest_name_validation.cpp
@@ -136,7 +136,7 @@ TEST_F(NameValidationXMLTest, ValidBehaviorTreeID)
         <AlwaysSuccess/>
       </BehaviorTree>
     </root>)";
-  EXPECT_NO_THROW(factory.createTreeFromText(xml));
+  EXPECT_NO_THROW((void)factory.createTreeFromText(xml));
 }
 
 TEST_F(NameValidationXMLTest, ValidBehaviorTreeID_WithUnderscore)
@@ -147,7 +147,7 @@ TEST_F(NameValidationXMLTest, ValidBehaviorTreeID_WithUnderscore)
         <AlwaysSuccess/>
       </BehaviorTree>
     </root>)";
-  EXPECT_NO_THROW(factory.createTreeFromText(xml));
+  EXPECT_NO_THROW((void)factory.createTreeFromText(xml));
 }
 
 TEST_F(NameValidationXMLTest, InvalidBehaviorTreeID_Root)
@@ -158,7 +158,7 @@ TEST_F(NameValidationXMLTest, InvalidBehaviorTreeID_Root)
         <AlwaysSuccess/>
       </BehaviorTree>
     </root>)";
-  EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
+  EXPECT_THROW((void)factory.createTreeFromText(xml), RuntimeError);
 }
 
 TEST_F(NameValidationXMLTest, InvalidBehaviorTreeID_root_lowercase)
@@ -169,7 +169,7 @@ TEST_F(NameValidationXMLTest, InvalidBehaviorTreeID_root_lowercase)
         <AlwaysSuccess/>
       </BehaviorTree>
     </root>)";
-  EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
+  EXPECT_THROW((void)factory.createTreeFromText(xml), RuntimeError);
 }
 
 TEST_F(NameValidationXMLTest, InvalidBehaviorTreeID_WithSpace)
@@ -180,7 +180,7 @@ TEST_F(NameValidationXMLTest, InvalidBehaviorTreeID_WithSpace)
         <AlwaysSuccess/>
       </BehaviorTree>
     </root>)";
-  EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
+  EXPECT_THROW((void)factory.createTreeFromText(xml), RuntimeError);
 }
 
 TEST_F(NameValidationXMLTest, InvalidBehaviorTreeID_WithPeriod)
@@ -191,7 +191,7 @@ TEST_F(NameValidationXMLTest, InvalidBehaviorTreeID_WithPeriod)
         <AlwaysSuccess/>
       </BehaviorTree>
     </root>)";
-  EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
+  EXPECT_THROW((void)factory.createTreeFromText(xml), RuntimeError);
 }
 
 TEST_F(NameValidationXMLTest, ValidInstanceName)
@@ -202,7 +202,7 @@ TEST_F(NameValidationXMLTest, ValidInstanceName)
         <AlwaysSuccess name="my_success_node"/>
       </BehaviorTree>
     </root>)";
-  EXPECT_NO_THROW(factory.createTreeFromText(xml));
+  EXPECT_NO_THROW((void)factory.createTreeFromText(xml));
 }
 
 TEST_F(NameValidationXMLTest, ValidInstanceName_WithSpace)
@@ -214,7 +214,7 @@ TEST_F(NameValidationXMLTest, ValidInstanceName_WithSpace)
         <AlwaysSuccess name="my success node"/>
       </BehaviorTree>
     </root>)";
-  EXPECT_NO_THROW(factory.createTreeFromText(xml));
+  EXPECT_NO_THROW((void)factory.createTreeFromText(xml));
 }
 
 TEST_F(NameValidationXMLTest, ValidInstanceName_WithPeriod)
@@ -226,7 +226,7 @@ TEST_F(NameValidationXMLTest, ValidInstanceName_WithPeriod)
         <AlwaysSuccess name="node.name"/>
       </BehaviorTree>
     </root>)";
-  EXPECT_NO_THROW(factory.createTreeFromText(xml));
+  EXPECT_NO_THROW((void)factory.createTreeFromText(xml));
 }
 
 TEST_F(NameValidationXMLTest, ValidSubTreeID)
@@ -240,7 +240,7 @@ TEST_F(NameValidationXMLTest, ValidSubTreeID)
         <AlwaysSuccess/>
       </BehaviorTree>
     </root>)";
-  EXPECT_NO_THROW(factory.createTreeFromText(xml));
+  EXPECT_NO_THROW((void)factory.createTreeFromText(xml));
 }
 
 TEST_F(NameValidationXMLTest, InvalidSubTreeID_WithSpace)
@@ -254,7 +254,7 @@ TEST_F(NameValidationXMLTest, InvalidSubTreeID_WithSpace)
         <AlwaysSuccess/>
       </BehaviorTree>
     </root>)";
-  EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
+  EXPECT_THROW((void)factory.createTreeFromText(xml), RuntimeError);
 }
 
 // ============== Tests for Unicode support ==============
@@ -267,7 +267,7 @@ TEST_F(NameValidationXMLTest, UnicodeTreeID_Chinese)
         <AlwaysSuccess/>
       </BehaviorTree>
     </root>)";
-  EXPECT_NO_THROW(factory.createTreeFromText(xml));
+  EXPECT_NO_THROW((void)factory.createTreeFromText(xml));
 }
 
 TEST_F(NameValidationXMLTest, UnicodeInstanceName_Japanese)
@@ -278,7 +278,7 @@ TEST_F(NameValidationXMLTest, UnicodeInstanceName_Japanese)
         <AlwaysSuccess name="成功ノード"/>
       </BehaviorTree>
     </root>)";
-  EXPECT_NO_THROW(factory.createTreeFromText(xml));
+  EXPECT_NO_THROW((void)factory.createTreeFromText(xml));
 }
 
 TEST_F(NameValidationXMLTest, UnicodeTreeID_German)
@@ -289,7 +289,7 @@ TEST_F(NameValidationXMLTest, UnicodeTreeID_German)
         <AlwaysSuccess/>
       </BehaviorTree>
     </root>)";
-  EXPECT_NO_THROW(factory.createTreeFromText(xml));
+  EXPECT_NO_THROW((void)factory.createTreeFromText(xml));
 }
 
 // ============== Tests for SubTree port validation ==============
@@ -310,7 +310,7 @@ TEST_F(NameValidationXMLTest, ValidSubTreePortName)
         </SubTree>
       </TreeNodesModel>
     </root>)";
-  EXPECT_NO_THROW(factory.createTreeFromText(xml));
+  EXPECT_NO_THROW((void)factory.createTreeFromText(xml));
 }
 
 TEST_F(NameValidationXMLTest, InvalidSubTreePortName_WithSpace)
@@ -326,7 +326,7 @@ TEST_F(NameValidationXMLTest, InvalidSubTreePortName_WithSpace)
         </SubTree>
       </TreeNodesModel>
     </root>)";
-  EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
+  EXPECT_THROW((void)factory.createTreeFromText(xml), RuntimeError);
 }
 
 TEST_F(NameValidationXMLTest, InvalidSubTreePortName_Reserved)
@@ -342,7 +342,7 @@ TEST_F(NameValidationXMLTest, InvalidSubTreePortName_Reserved)
         </SubTree>
       </TreeNodesModel>
     </root>)";
-  EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
+  EXPECT_THROW((void)factory.createTreeFromText(xml), RuntimeError);
 }
 
 TEST_F(NameValidationXMLTest, InvalidSubTreePortName_StartsWithDigit)
@@ -358,5 +358,5 @@ TEST_F(NameValidationXMLTest, InvalidSubTreePortName_StartsWithDigit)
         </SubTree>
       </TreeNodesModel>
     </root>)";
-  EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
+  EXPECT_THROW((void)factory.createTreeFromText(xml), RuntimeError);
 }

--- a/tests/gtest_try_catch.cpp
+++ b/tests/gtest_try_catch.cpp
@@ -209,7 +209,7 @@ TEST_F(TryCatchTest, MinimumTwoChildren_ParseTimeValidation)
     </root>)";
 
   // Error should be caught at parse time, not tick time
-  ASSERT_THROW(factory.createTreeFromText(xml_text), BT::RuntimeError);
+  ASSERT_THROW((void)factory.createTreeFromText(xml_text), BT::RuntimeError);
 }
 
 TEST_F(TryCatchTest, ReExecuteAfterSuccess)


### PR DESCRIPTION
Hi! I am testing Nav2 in Lyrical, and as we treat warnings as errors, we are unable to compile it, this PR fixes the issue + also fixes the -Wunused-result


<details>
  <summary>Building BT.CPP</summary>
  
```cpp
 In file included from /root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/utils/convert_impl.hpp:15,
                 from /root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/utils/safe_any.hpp:21,
                 from /root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/basic_types.h:5,
                 from /root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/blackboard.h:3,
                 from /root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/scripting/script_parser.hpp:15,
                 from /root/nav2_ws/src/BehaviorTree.CPP/src/script_parser.cpp:13:
In destructor ‘SafeAny::SimpleString::~SimpleString()’,
    inlined from ‘void nonstd::expected_lite::detail::storage_t_impl<T, E>::destruct_value() [with T = SafeAny::SimpleString; E = std::__cxx11::basic_string<char>]’ at /root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/contrib/expected.hpp:705:28,
    inlined from ‘nonstd::expected_lite::expected<T, E>::~expected() [with T = SafeAny::SimpleString; E = std::__cxx11::basic_string<char>]’ at /root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/contrib/expected.hpp:2038:52,
    inlined from ‘nonstd::expected_lite::expected<T, E>::~expected() [with T = SafeAny::SimpleString; E = std::__cxx11::basic_string<char>]’ at /root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/contrib/expected.hpp:2036:5,
    inlined from ‘nonstd::expected_lite::expected<T, std::__cxx11::basic_string<char> > BT::Any::tryCast() const [with T = SafeAny::SimpleString]’ at /root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/utils/safe_any.hpp:561:3,
    inlined from ‘T BT::Any::cast() const [with T = SafeAny::SimpleString]’ at /root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/utils/safe_any.hpp:170:13:
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/utils/simple_string.hpp:72:29: warning: ‘void operator delete [](void*)’ called on unallocated object ‘res’ [-Wfree-nonheap-object]
   72 |       delete[] _storage.str.data;
      |                             ^~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/utils/safe_any.hpp: In member function ‘T BT::Any::cast() const [with T = SafeAny::SimpleString]’:
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/utils/safe_any.hpp:561:11: note: declared here
  561 |   if(auto res = convert<T>())
      |           ^~~
In file included from /usr/include/gtest/gtest-printers.h:122,
                 from /usr/include/gtest/gtest-matchers.h:49,
                 from /usr/include/gtest/internal/gtest-death-test-internal.h:47,
                 from /usr/include/gtest/gtest-death-test.h:43,
                 from /usr/include/gtest/gtest.h:64,
                 from /root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp:8:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp: In member function ‘virtual void BehaviorTreeFactory_NotRegisteredNode_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp:115:46: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  115 |   ASSERT_ANY_THROW(factory.createTreeFromText(xml_text));
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
In file included from /root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_parser.h:16,
                 from /root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/xml_parsing.h:4,
                 from /root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp:1:
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp: In member function ‘virtual void BehaviorTreeFactory_MalformedXML_InvalidRoot_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp:626:46: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  626 |   EXPECT_ANY_THROW(factory.createTreeFromText("<not valid xml!!!"));
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp: In member function ‘virtual void BehaviorTreeFactory_MalformedXML_MissingRootElement_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp:640:42: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  640 |   EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp: In member function ‘virtual void BehaviorTreeFactory_MalformedXML_EmptyBehaviorTree_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp:653:42: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  653 |   EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp: In member function ‘virtual void BehaviorTreeFactory_MalformedXML_EmptyBehaviorTreeID_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp:670:42: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  670 |   EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp: In member function ‘virtual void BehaviorTreeFactory_MalformedXML_MissingBehaviorTreeID_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp:687:42: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  687 |   EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp: In member function ‘virtual void BehaviorTreeFactory_MalformedXML_DeeplyNestedElements_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp:709:42: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  709 |   EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp: In member function ‘virtual void BehaviorTreeFactory_MalformedXML_ModerateNestingIsOK_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp:730:45: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  730 |   EXPECT_NO_THROW(factory.createTreeFromText(xml));
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp: In member function ‘virtual void BehaviorTreeFactory_MalformedXML_MultipleBTChildElements_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp:745:42: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  745 |   EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp: In member function ‘virtual void BehaviorTreeFactory_MalformedXML_CompletelyEmpty_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp:752:46: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  752 |   EXPECT_ANY_THROW(factory.createTreeFromText(""));
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp: In member function ‘virtual void BehaviorTreeFactory_MalformedXML_EmptyRoot_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp:764:38: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTree(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  764 |   EXPECT_ANY_THROW(factory.createTree("MainTree"));
      |                    ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:468:22: note: declared here
  468 |   [[nodiscard]] Tree createTree(const std::string& tree_name,
      |                      ^~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp: In member function ‘virtual void BehaviorTreeFactory_MalformedXML_UnknownNodeType_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_factory.cpp:778:42: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  778 |   EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
In file included from /usr/include/gtest/gtest-printers.h:122,
                 from /usr/include/gtest/gtest-matchers.h:49,
                 from /usr/include/gtest/internal/gtest-death-test-internal.h:47,
                 from /usr/include/gtest/gtest-death-test.h:43,
                 from /usr/include/gtest/gtest.h:64,
                 from /root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp:5:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp: In member function ‘virtual void NameValidationXMLTest_ValidBehaviorTreeID_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp:139:45: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  139 |   EXPECT_NO_THROW(factory.createTreeFromText(xml));
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
In file included from /root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp:2:
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp: In member function ‘virtual void NameValidationXMLTest_ValidBehaviorTreeID_WithUnderscore_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp:150:45: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  150 |   EXPECT_NO_THROW(factory.createTreeFromText(xml));
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp: In member function ‘virtual void NameValidationXMLTest_InvalidBehaviorTreeID_Root_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp:161:42: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  161 |   EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp: In member function ‘virtual void NameValidationXMLTest_InvalidBehaviorTreeID_root_lowercase_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp:172:42: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  172 |   EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp: In member function ‘virtual void NameValidationXMLTest_InvalidBehaviorTreeID_WithSpace_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp:183:42: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  183 |   EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp: In member function ‘virtual void NameValidationXMLTest_InvalidBehaviorTreeID_WithPeriod_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp:194:42: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  194 |   EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp: In member function ‘virtual void NameValidationXMLTest_ValidInstanceName_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp:205:45: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  205 |   EXPECT_NO_THROW(factory.createTreeFromText(xml));
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp: In member function ‘virtual void NameValidationXMLTest_ValidInstanceName_WithSpace_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp:217:45: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  217 |   EXPECT_NO_THROW(factory.createTreeFromText(xml));
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp: In member function ‘virtual void NameValidationXMLTest_ValidInstanceName_WithPeriod_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp:229:45: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  229 |   EXPECT_NO_THROW(factory.createTreeFromText(xml));
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp: In member function ‘virtual void NameValidationXMLTest_ValidSubTreeID_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp:243:45: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  243 |   EXPECT_NO_THROW(factory.createTreeFromText(xml));
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp: In member function ‘virtual void NameValidationXMLTest_InvalidSubTreeID_WithSpace_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp:257:42: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  257 |   EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp: In member function ‘virtual void NameValidationXMLTest_UnicodeTreeID_Chinese_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp:270:45: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  270 |   EXPECT_NO_THROW(factory.createTreeFromText(xml));
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp: In member function ‘virtual void NameValidationXMLTest_UnicodeInstanceName_Japanese_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp:281:45: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  281 |   EXPECT_NO_THROW(factory.createTreeFromText(xml));
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp: In member function ‘virtual void NameValidationXMLTest_UnicodeTreeID_German_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp:292:45: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  292 |   EXPECT_NO_THROW(factory.createTreeFromText(xml));
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp: In member function ‘virtual void NameValidationXMLTest_ValidSubTreePortName_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp:313:45: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  313 |   EXPECT_NO_THROW(factory.createTreeFromText(xml));
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp: In member function ‘virtual void NameValidationXMLTest_InvalidSubTreePortName_WithSpace_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp:329:42: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  329 |   EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp: In member function ‘virtual void NameValidationXMLTest_InvalidSubTreePortName_Reserved_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp:345:42: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  345 |   EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp: In member function ‘virtual void NameValidationXMLTest_InvalidSubTreePortName_StartsWithDigit_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_name_validation.cpp:361:42: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  361 |   EXPECT_THROW(factory.createTreeFromText(xml), RuntimeError);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
In file included from /usr/include/gtest/gtest-printers.h:122,
                 from /usr/include/gtest/gtest-matchers.h:49,
                 from /usr/include/gtest/internal/gtest-death-test-internal.h:47,
                 from /usr/include/gtest/gtest-death-test.h:43,
                 from /usr/include/gtest/gtest.h:64,
                 from /root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_try_catch.cpp:17:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_try_catch.cpp: In member function ‘virtual void TryCatchTest_MinimumTwoChildren_ParseTimeValidation_Test::TestBody()’:
/root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_try_catch.cpp:212:42: warning: ignoring return value of ‘BT::Tree BT::BehaviorTreeFactory::createTreeFromText(const std::string&, BT::Blackboard::Ptr)’, declared with attribute ‘nodiscard’ [-Wunused-result]
  212 |   ASSERT_THROW(factory.createTreeFromText(xml_text), BT::RuntimeError);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
In file included from /root/nav2_ws/src/BehaviorTree.CPP/tests/test_helper.hpp:4,
                 from /root/nav2_ws/src/BehaviorTree.CPP/tests/gtest_try_catch.cpp:13:
/root/nav2_ws/src/BehaviorTree.CPP/include/behaviortree_cpp/bt_factory.h:450:22: note: declared here
  450 |   [[nodiscard]] Tree createTreeFromText(
      |                      ^~~~~~~~~~~~~~~~~~
---
Finished <<< behaviortree_cpp [46.1s]
```

</details>


<details>
  <summary>Building Nav2</summary>

```cpp
-- stderr: nav2_behavior_tree                                                                                            
In file included from /usr/include/x86_64-linux-gnu/c++/15/bits/c++allocator.h:33,
                 from /usr/include/c++/15/bits/allocator.h:46,
                 from /usr/include/c++/15/string:45,
                 from /root/nav2_ws/src/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/are_error_codes_present_condition.hpp:18,
                 from /root/nav2_ws/src/navigation2/nav2_behavior_tree/plugins/condition/are_error_codes_present_condition.cpp:15:
In member function ‘void std::__new_allocator<_Tp>::deallocate(_Tp*, size_type) [with _Tp = int]’,
    inlined from ‘constexpr void std::allocator< <template-parameter-1-1> >::deallocate(_Tp*, std::size_t) [with _Tp = int]’ at /usr/include/c++/15/bits/allocator.h:215:35,
    inlined from ‘static constexpr void std::allocator_traits<std::allocator<_CharT> >::deallocate(allocator_type&, pointer, size_type) [with _Tp = int]’ at /usr/include/c++/15/bits/alloc_traits.h:649:23,
    inlined from ‘constexpr void std::_Vector_base<_Tp, _Alloc>::_M_deallocate(pointer, std::size_t) [with _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/15/bits/stl_vector.h:396:19,
    inlined from ‘constexpr std::_Vector_base<_Tp, _Alloc>::~_Vector_base() [with _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/15/bits/stl_vector.h:375:15,
    inlined from ‘constexpr std::vector<_Tp, _Alloc>::~vector() [with _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/15/bits/stl_vector.h:805:7,
    inlined from ‘void nonstd::expected_lite::detail::storage_t_impl<T, E>::destruct_value() [with T = std::vector<int>; E = std::__cxx11::basic_string<char>]’ at /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/contrib/expected.hpp:705:28,
    inlined from ‘nonstd::expected_lite::expected<T, E>::~expected() [with T = std::vector<int>; E = std::__cxx11::basic_string<char>]’ at /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/contrib/expected.hpp:2038:52,
    inlined from ‘nonstd::expected_lite::expected<T, std::__cxx11::basic_string<char> > BT::Any::tryCast() const [with T = std::vector<int>]’ at /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/utils/safe_any.hpp:561:3:
/usr/include/c++/15/bits/new_allocator.h:172:66: warning: ‘void operator delete(void*, std::size_t)’ called on unallocated object ‘res’ [-Wfree-nonheap-object]
  172 |         _GLIBCXX_OPERATOR_DELETE(_GLIBCXX_SIZED_DEALLOC(__p, __n));
      |                                                                  ^
In file included from /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/basic_types.h:5,
                 from /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/tree_node.h:16,
                 from /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/leaf_node.h:17,
                 from /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/condition_node.h:17,
                 from /root/nav2_ws/src/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/are_error_codes_present_condition.hpp:24:
/root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/utils/safe_any.hpp: In member function ‘nonstd::expected_lite::expected<T, std::__cxx11::basic_string<char> > BT::Any::tryCast() const [with T = std::vector<int>]’:
/root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/utils/safe_any.hpp:561:11: note: declared here
  561 |   if(auto res = convert<T>())
      |           ^~~
In file included from /usr/include/x86_64-linux-gnu/c++/15/bits/c++allocator.h:33,
                 from /usr/include/c++/15/bits/allocator.h:46,
                 from /usr/include/c++/15/string:45,
                 from /root/nav2_ws/src/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/would_a_controller_recovery_help_condition.hpp:18,
                 from /root/nav2_ws/src/navigation2/nav2_behavior_tree/plugins/condition/would_a_controller_recovery_help_condition.cpp:15:
In member function ‘void std::__new_allocator<_Tp>::deallocate(_Tp*, size_type) [with _Tp = int]’,
    inlined from ‘constexpr void std::allocator< <template-parameter-1-1> >::deallocate(_Tp*, std::size_t) [with _Tp = int]’ at /usr/include/c++/15/bits/allocator.h:215:35,
    inlined from ‘static constexpr void std::allocator_traits<std::allocator<_CharT> >::deallocate(allocator_type&, pointer, size_type) [with _Tp = int]’ at /usr/include/c++/15/bits/alloc_traits.h:649:23,
    inlined from ‘constexpr void std::_Vector_base<_Tp, _Alloc>::_M_deallocate(pointer, std::size_t) [with _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/15/bits/stl_vector.h:396:19,
    inlined from ‘constexpr std::_Vector_base<_Tp, _Alloc>::~_Vector_base() [with _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/15/bits/stl_vector.h:375:15,
    inlined from ‘constexpr std::vector<_Tp, _Alloc>::~vector() [with _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/15/bits/stl_vector.h:805:7,
    inlined from ‘void nonstd::expected_lite::detail::storage_t_impl<T, E>::destruct_value() [with T = std::vector<int>; E = std::__cxx11::basic_string<char>]’ at /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/contrib/expected.hpp:705:28,
    inlined from ‘nonstd::expected_lite::expected<T, E>::~expected() [with T = std::vector<int>; E = std::__cxx11::basic_string<char>]’ at /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/contrib/expected.hpp:2038:52,
    inlined from ‘nonstd::expected_lite::expected<T, std::__cxx11::basic_string<char> > BT::Any::tryCast() const [with T = std::vector<int>]’ at /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/utils/safe_any.hpp:561:3:
/usr/include/c++/15/bits/new_allocator.h:172:66: warning: ‘void operator delete(void*, std::size_t)’ called on unallocated object ‘res’ [-Wfree-nonheap-object]
  172 |         _GLIBCXX_OPERATOR_DELETE(_GLIBCXX_SIZED_DEALLOC(__p, __n));
      |                                                                  ^
In file included from /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/basic_types.h:5,
                 from /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/tree_node.h:16,
                 from /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/leaf_node.h:17,
                 from /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/condition_node.h:17,
                 from /root/nav2_ws/src/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/are_error_codes_present_condition.hpp:24,
                 from /root/nav2_ws/src/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/would_a_controller_recovery_help_condition.hpp:21:
/root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/utils/safe_any.hpp: In member function ‘nonstd::expected_lite::expected<T, std::__cxx11::basic_string<char> > BT::Any::tryCast() const [with T = std::vector<int>]’:
/root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/utils/safe_any.hpp:561:11: note: declared here
  561 |   if(auto res = convert<T>())
      |           ^~~
In file included from /usr/include/x86_64-linux-gnu/c++/15/bits/c++allocator.h:33,
                 from /usr/include/c++/15/bits/allocator.h:46,
                 from /usr/include/c++/15/string:45,
                 from /root/nav2_ws/src/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/would_a_planner_recovery_help_condition.hpp:18,
                 from /root/nav2_ws/src/navigation2/nav2_behavior_tree/plugins/condition/would_a_planner_recovery_help_condition.cpp:15:
In member function ‘void std::__new_allocator<_Tp>::deallocate(_Tp*, size_type) [with _Tp = int]’,
    inlined from ‘constexpr void std::allocator< <template-parameter-1-1> >::deallocate(_Tp*, std::size_t) [with _Tp = int]’ at /usr/include/c++/15/bits/allocator.h:215:35,
    inlined from ‘static constexpr void std::allocator_traits<std::allocator<_CharT> >::deallocate(allocator_type&, pointer, size_type) [with _Tp = int]’ at /usr/include/c++/15/bits/alloc_traits.h:649:23,
    inlined from ‘constexpr void std::_Vector_base<_Tp, _Alloc>::_M_deallocate(pointer, std::size_t) [with _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/15/bits/stl_vector.h:396:19,
    inlined from ‘constexpr std::_Vector_base<_Tp, _Alloc>::~_Vector_base() [with _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/15/bits/stl_vector.h:375:15,
    inlined from ‘constexpr std::vector<_Tp, _Alloc>::~vector() [with _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/15/bits/stl_vector.h:805:7,
    inlined from ‘void nonstd::expected_lite::detail::storage_t_impl<T, E>::destruct_value() [with T = std::vector<int>; E = std::__cxx11::basic_string<char>]’ at /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/contrib/expected.hpp:705:28,
    inlined from ‘nonstd::expected_lite::expected<T, E>::~expected() [with T = std::vector<int>; E = std::__cxx11::basic_string<char>]’ at /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/contrib/expected.hpp:2038:52,
    inlined from ‘nonstd::expected_lite::expected<T, std::__cxx11::basic_string<char> > BT::Any::tryCast() const [with T = std::vector<int>]’ at /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/utils/safe_any.hpp:561:3:
/usr/include/c++/15/bits/new_allocator.h:172:66: warning: ‘void operator delete(void*, std::size_t)’ called on unallocated object ‘res’ [-Wfree-nonheap-object]
  172 |         _GLIBCXX_OPERATOR_DELETE(_GLIBCXX_SIZED_DEALLOC(__p, __n));
      |                                                                  ^
In file included from /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/basic_types.h:5,
                 from /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/tree_node.h:16,
                 from /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/leaf_node.h:17,
                 from /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/condition_node.h:17,
                 from /root/nav2_ws/src/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/are_error_codes_present_condition.hpp:24,
                 from /root/nav2_ws/src/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/would_a_planner_recovery_help_condition.hpp:22:
/root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/utils/safe_any.hpp: In member function ‘nonstd::expected_lite::expected<T, std::__cxx11::basic_string<char> > BT::Any::tryCast() const [with T = std::vector<int>]’:
/root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/utils/safe_any.hpp:561:11: note: declared here
  561 |   if(auto res = convert<T>())
      |           ^~~
In file included from /usr/include/x86_64-linux-gnu/c++/15/bits/c++allocator.h:33,
                 from /usr/include/c++/15/bits/allocator.h:46,
                 from /usr/include/c++/15/string:45,
                 from /root/nav2_ws/src/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/would_a_smoother_recovery_help_condition.hpp:19,
                 from /root/nav2_ws/src/navigation2/nav2_behavior_tree/plugins/condition/would_a_smoother_recovery_help_condition.cpp:15:
In member function ‘void std::__new_allocator<_Tp>::deallocate(_Tp*, size_type) [with _Tp = int]’,
    inlined from ‘constexpr void std::allocator< <template-parameter-1-1> >::deallocate(_Tp*, std::size_t) [with _Tp = int]’ at /usr/include/c++/15/bits/allocator.h:215:35,
    inlined from ‘static constexpr void std::allocator_traits<std::allocator<_CharT> >::deallocate(allocator_type&, pointer, size_type) [with _Tp = int]’ at /usr/include/c++/15/bits/alloc_traits.h:649:23,
    inlined from ‘constexpr void std::_Vector_base<_Tp, _Alloc>::_M_deallocate(pointer, std::size_t) [with _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/15/bits/stl_vector.h:396:19,
    inlined from ‘constexpr std::_Vector_base<_Tp, _Alloc>::~_Vector_base() [with _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/15/bits/stl_vector.h:375:15,
    inlined from ‘constexpr std::vector<_Tp, _Alloc>::~vector() [with _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/15/bits/stl_vector.h:805:7,
    inlined from ‘void nonstd::expected_lite::detail::storage_t_impl<T, E>::destruct_value() [with T = std::vector<int>; E = std::__cxx11::basic_string<char>]’ at /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/contrib/expected.hpp:705:28,
    inlined from ‘nonstd::expected_lite::expected<T, E>::~expected() [with T = std::vector<int>; E = std::__cxx11::basic_string<char>]’ at /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/contrib/expected.hpp:2038:52,
    inlined from ‘nonstd::expected_lite::expected<T, std::__cxx11::basic_string<char> > BT::Any::tryCast() const [with T = std::vector<int>]’ at /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/utils/safe_any.hpp:561:3:
/usr/include/c++/15/bits/new_allocator.h:172:66: warning: ‘void operator delete(void*, std::size_t)’ called on unallocated object ‘res’ [-Wfree-nonheap-object]
  172 |         _GLIBCXX_OPERATOR_DELETE(_GLIBCXX_SIZED_DEALLOC(__p, __n));
      |                                                                  ^
In file included from /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/basic_types.h:5,
                 from /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/tree_node.h:16,
                 from /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/leaf_node.h:17,
                 from /root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/condition_node.h:17,
                 from /root/nav2_ws/src/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/are_error_codes_present_condition.hpp:24,
                 from /root/nav2_ws/src/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/would_a_smoother_recovery_help_condition.hpp:22:
/root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/utils/safe_any.hpp: In member function ‘nonstd::expected_lite::expected<T, std::__cxx11::basic_string<char> > BT::Any::tryCast() const [with T = std::vector<int>]’:
/root/nav2_ws/install/behaviortree_cpp/include/behaviortree_cpp/utils/safe_any.hpp:561:11: note: declared here
  561 |   if(auto res = convert<T>())
```

</details>