### PR TITLE
Jazzy release 3.8.8

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package behaviortree_cpp
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+3.8.8 (2026-06-03)
+------------------
 * Require C++17 to match ament_index_cpp 1.8.3+
 * Contributors: Davide Faconti, Marco A. Gutierrez
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package behaviortree_cpp
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Require C++17 to match ament_index_cpp 1.8.3+
+* Contributors: Davide Faconti, Marco A. Gutierrez
+
 3.8.7 (2024-06-26)
 ------------------
 * Backport of some build-related flatbuffers changes (`#825 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/825>`_)

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>behaviortree_cpp_v3</name>
-  <version>3.8.7</version>
+  <version>3.8.8</version>
   <description>
   This package provides the Behavior Trees core library.
   </description>


### PR DESCRIPTION
@facontidavide let's make a release of the `Jazzy` fix so we can remove the current [regression](https://repo.ros2.org/status_page/ros_jazzy_default.html?q=REGRESSION). 
