### PR TITLE
Use GNUInstallDirs with CACHE variables for install destinations (fixes #1120)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,9 +28,11 @@ option(USE_VENDORED_FLATBUFFERS "Use the bundled version of flatbuffers" ON)
 option(USE_VENDORED_MINICORO "Use the bundled version of minicoro" ON)
 option(USE_VENDORED_MINITRACE "Use the bundled version of minitrace" ON)
 
-set(BTCPP_LIB_DESTINATION     lib)
-set(BTCPP_INCLUDE_DESTINATION include)
-set(BTCPP_BIN_DESTINATION     bin)
+include(GNUInstallDirs)
+
+set(BTCPP_LIB_DESTINATION     "${CMAKE_INSTALL_LIBDIR}"     CACHE STRING "Library installation directory")
+set(BTCPP_INCLUDE_DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}" CACHE STRING "Header installation directory")
+set(BTCPP_BIN_DESTINATION     "${CMAKE_INSTALL_BINDIR}"     CACHE STRING "Binary installation directory")
 
 set(BASE_FLAGS "")
 


### PR DESCRIPTION
Fixes #1120

## Problem

The install destination variables use plain `set()`, which prevents overriding them from the CMake command line. This blocks Debian/Ubuntu packagers from installing to multiarch directories (e.g. `lib/x86_64-linux-gnu`).

## Solution

`include(GNUInstallDirs)` with `set(... CACHE STRING ...)` defaults.
 
Two override mechanisms:

 - `-DBTCPP_LIB_DESTINATION=lib/x86_64-linux-gnu` (project-specific)
 - `-DCMAKE_INSTALL_LIBDIR=lib/x86_64-linux-gnu` (system-wide, standard)

## API / ABI / Backward compatibility

 No API or ABI changes: this is a build system change only.

 - **ROS2/ament builds**: unaffected. `ament_build.cmake` only calls `mark_as_advanced()` on these variables; ament handles installation separately.
 - **Standard Linux**: `CMAKE_INSTALL_LIBDIR` resolves to `lib`: no change from current behavior.
 - **Existing `-DBTCPP_LIB_DESTINATION=...` usage**: still works, CACHE variable takes precedence.

## Pre-commit / clang-tidy

Not applicable: this PR changes only `CMakeLists.txt`. The `clang-format` and `clang-tidy` hooks target `.cpp/.hpp/.h` files only.

## Verified

| Check | Result |
|-------|--------|
| Configure (default) | `BTCPP_LIB_DESTINATION: lib` |
| Build | 100% (45 TUs, no warnings) |
| Install (default) | `lib/libbehaviortree_cpp.so` |
| Override | `-DBTCPP_LIB_DESTINATION=custom/lib` -> `custom/lib/libbehaviortree_cpp.so` |