### PR TITLE
Fix remove duplicated vars in xml parsing

### DIFF
--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -806,9 +806,6 @@ TreeNode::Ptr XMLParser::PImpl::createNodeFromXML(const XMLElement* element,
     const std::string port_value = att->Value();
     if(IsAllowedPortName(port_name))
     {
-      const std::string port_name = att->Name();
-      const std::string port_value = att->Value();
-
       if(manifest != nullptr)
       {
         auto port_model_it = manifest->ports.find(port_name);


### PR DESCRIPTION
<!--
## Instructions

- Unless your code is self explaining, add comments.
- Consider if your proposed changes introduces API, ABI, back-compatibility or behavioral changes.
- If your code is fixing a bug, please create a unit test to reproduce the bug, i.e. a test that fails before the fix and pass after the fix.
- You use [pre-commit](https://pre-commit.com/) to apply automatically all the required linting rules (clang-format in particular).
- You should also execute the script `./run_clang_tidy.sh` and correct all the warnings.

Please read the CONTRIBUTORS_GUIDE.md file for details and instructions.
-->
In src/xml_parsing.cpp, XMLParser::PImpl::createNodeFromXML(), port_name and port_value were declared at the outer scope of the attribute-iteration loop, then immediately re-declared with identical values inside the if(IsAllowedPortName(...)) block, shadowing the outer variables.

The inner declarations (lines 809–810) are dead code and have been removed. Behavior is unchanged.

Resolve #1153 

Checklist
•  No API / ABI / behavioral changes introduced
•  No new unit test needed (the change is a pure dead-code removal with no behavioral effect)
•  pre-commit applied
•  ./run_clang_tidy.sh executed and clean