### PR TITLE
CI: Pin Windows runners to windows-2022

### DIFF
--- a/.github/workflows/cmake_windows.yml
+++ b/.github/workflows/cmake_windows.yml
@@ -16,7 +16,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest]
+        # Pinned to windows-2022: windows-latest now ships Visual Studio 2026
+        # (MSVC 19.5), which makes Conan request the "Visual Studio 18 2026"
+        # generator that the installed CMake cannot create.
+        os: [windows-2022]
         build_type: [Release, Debug]
 
     steps:

--- a/.github/workflows/pixi.yaml
+++ b/.github/workflows/pixi.yaml
@@ -14,9 +14,13 @@ concurrency:
 jobs:
   pixi_conda_build:
     strategy:
+      fail-fast: false
       matrix:
         os:
-          - windows-latest
+          # Pinned to windows-2022: windows-latest now ships Visual Studio 2026,
+          # but cmake defaults to the "Visual Studio 17 2022" generator, which is
+          # no longer present ("could not find any instance of Visual Studio").
+          - windows-2022
           - ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Problem

`windows-latest` GitHub-hosted runners have been upgraded to **Visual Studio 2026** (MSVC 19.5). This breaks both Windows CI jobs on **every** current PR:

- **`cmake Windows`** (Debug & Release) — `conan profile detect` selects `msvc 195`, so Conan asks CMake for the `Visual Studio 18 2026` generator, which the installed CMake cannot create. The vendored `foonathan-lexy` dependency fails to build:
  ```
  CMake Error: Could not create named generator Visual Studio 18 2026
  ```
- **`Pixi (conda)`** (windows) — `cmake ..` defaults to the `Visual Studio 17 2022` generator, which is no longer present:
  ```
  Generator Visual Studio 17 2022 could not find any instance of Visual Studio.
  ```
- **`Pixi (conda)`** (ubuntu) was not actually broken — it was cancelled by fail-fast when the Windows leg died.

This is an environment regression, not a code change: the same failures currently hit #1152, #1154, and #1155, while older PRs (#1145, #1146) passed. `master` last ran these jobs green on 2026-05-19, before the runner upgrade.

## Fix

- Pin both Windows jobs to `windows-2022` (VS 2022 / MSVC 19.3x), a CMake + generator combo that both Conan and pixi already work with.
- Set `fail-fast: false` on the pixi matrix so a Windows failure no longer masks the ubuntu leg's real status.

This unblocks the currently-red PRs (#1152, #1154, #1155). A forward-looking follow-up could instead make the build VS 2026-compatible (newer CMake / force the Ninja generator), but pinning restores green CI reliably today.

## Note

The `ros2-rolling` failure seen on recent PRs is a separate, transient ROS Rolling apt-repo outage (`Unable to locate package ros-rolling-ros-environment`) and is not addressed here — it clears on re-run.