### PR TITLE
CI: Pin ros2-rolling to Ubuntu Noble until Rolling ships for Resolute (26.04)

### DIFF
--- a/.github/workflows/ros2-rolling.yaml
+++ b/.github/workflows/ros2-rolling.yaml
@@ -16,7 +16,9 @@ jobs:
     strategy:
       matrix:
         env:
-          - {ROS_DISTRO: rolling, ROS_REPO: main}
+          # rolling now targets Ubuntu 26.04 (resolute), which has no rolling
+          # debs yet. Pin to noble (24.04) until resolute is published.
+          - {ROS_DISTRO: rolling, ROS_REPO: main, OS_CODE_NAME: noble}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

`industrial_ci@master` now resolves `ROS_DISTRO=rolling` to **`ubuntu:resolute`** (Ubuntu 26.04) — Rolling's new target platform. But Rolling debs aren't published for `resolute` yet, so `setup_rosdep` fails on every PR:

```
$ docker pull ubuntu:resolute
...
$ sudo apt-get -qq install -y --no-upgrade --no-install-recommends ros-rolling-ros-environment
E: Unable to locate package ros-rolling-ros-environment
'setup_rosdep' returned with code '100'
```

Confirmed directly against the ROS 2 apt repo (`packages.ros.org/ros2/ubuntu`):

| Codename | `ros-rolling-ros-environment` |
|----------|-------------------------------|
| `resolute` (26.04, new default) | missing |
| `noble` (24.04)                 | present |

This is deterministic (not flaky) and hits all open PRs; it will stay red until the ROS build farm rebuilds Rolling for 26.04.

## Fix

Pin the rolling job to Ubuntu Noble with `OS_CODE_NAME: noble`. industrial_ci explicitly supports rolling-on-noble (`industrial_ci/src/ros.sh`) and auto-pins the distro index to the last Noble-compatible snapshot (`rolling/2026-04-28`), so the check keeps **actually building** rather than being red or ignored.

```yaml
- {ROS_DISTRO: rolling, ROS_REPO: main, OS_CODE_NAME: noble}
```