### PR TITLE
Fix build with Apple libc++ lacking floating-point std::from_chars

### DIFF
--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -13,6 +13,7 @@
 #include "behaviortree_cpp/basic_types.h"
 
 #include <charconv>
+#include <clocale>
 #include <cstdio>
 #include <cstring>
 #include <functional>
@@ -1189,8 +1190,24 @@ void BT::XMLParser::PImpl::recursivelyCreateSubtree(
             if(!stored)
             {
               double dbl_val = 0;
+#if __cpp_lib_to_chars >= 201611L
               auto [ptr, ec] = std::from_chars(begin, end, dbl_val);
               if(ec == std::errc() && ptr == end)
+#else
+              const std::string old_locale = setlocale(LC_NUMERIC, nullptr);
+              std::ignore = setlocale(LC_NUMERIC, "C");
+              std::size_t dbl_pos = 0;
+              try
+              {
+                dbl_val = std::stod(str_value, &dbl_pos);
+              }
+              catch(...)
+              {
+                dbl_pos = 0;
+              }
+              std::ignore = setlocale(LC_NUMERIC, old_locale.c_str());
+              if(dbl_pos == str_value.size())
+#endif
               {
                 new_bb->set(attr_name, dbl_val);
                 stored = true;


### PR DESCRIPTION
<!--
## Instructions

- Unless your code is self explaining, add comments.
- Consider if your proposed changes introduces API, ABI, back-compatibility or behavioral changes.
- If your code is fixing a bug, please create a unit test to reproduce the bug, i.e. a test that fails before the fix and pass after the fix.
- You use [pre-commit](https://pre-commit.com/) to apply automatically all the required linting rules (clang-format in particular).
- You should also execute the script `./run_clang_tidy.sh` and correct all the warnings.

Please read the CONTRIBUTORS_GUIDE.md file for details and instructions.
-->


Apple's libc++ deletes floating-point `std::from_chars` (and undefines
`__cpp_lib_to_chars`), so the unguarded `double` parse in `xml_parsing.cpp`
fails to compile on macOS.

Guard it like the other numeric conversions and fall back to `std::stod`,
keeping the strict full-string validation. Backward-compatible; compile-only
fix (no unit test).