### PR TITLE
fix out-of-bounds read in isBlackboardPointer whitespace trim

### DIFF
--- a/src/tree_node.cpp
+++ b/src/tree_node.cpp
@@ -396,11 +396,11 @@ bool TreeNode::isBlackboardPointer(StringView str, StringView* stripped_pointer)
   // strip leading and following spaces
   size_t front_index = 0;
   size_t last_index = str.size() - 1;
-  while(str[front_index] == ' ' && front_index <= last_index)
+  while(front_index <= last_index && str[front_index] == ' ')
   {
     front_index++;
   }
-  while(str[last_index] == ' ' && front_index <= last_index)
+  while(front_index <= last_index && str[last_index] == ' ')
   {
     last_index--;
   }

--- a/tests/gtest_ports.cpp
+++ b/tests/gtest_ports.cpp
@@ -869,3 +869,21 @@ TEST(PortTest, SubtreeStringLiteralToLoopDouble_Issue1065)
   EXPECT_DOUBLE_EQ(collected[1], 2.0);
   EXPECT_DOUBLE_EQ(collected[2], 3.0);
 }
+
+TEST(PortTest, IsBlackboardPointerAllWhitespaceView)
+{
+  // A view made only of spaces must not be read past its end while trimming.
+  // Use a buffer that is not null-terminated so AddressSanitizer catches the
+  // over-read on the character after the last space.
+  std::vector<char> only_spaces(3, ' ');
+  const StringView spaces_view(only_spaces.data(), only_spaces.size());
+  EXPECT_FALSE(TreeNode::isBlackboardPointer(spaces_view));
+
+  // Trimming and detection of real pointers is unchanged.
+  StringView stripped;
+  EXPECT_TRUE(TreeNode::isBlackboardPointer("{key}", &stripped));
+  EXPECT_EQ(stripped, "key");
+  EXPECT_TRUE(TreeNode::isBlackboardPointer("  {key}  ", &stripped));
+  EXPECT_EQ(stripped, "key");
+  EXPECT_FALSE(TreeNode::isBlackboardPointer("value"));
+}


### PR DESCRIPTION
isBlackboardPointer trims leading and trailing spaces with two while loops before it checks for the {...} pattern, and each loop tests the character before it tests the index against the bounds. Because of the short-circuit order, str[front_index] is read first and front_index <= last_index only after. When the whole value is spaces, front_index walks up to str.size() and the loop reads one element past the end before the bounds check would have stopped it. The argument is a std::string_view, so that trailing byte is not guaranteed to be there; I ran into it under AddressSanitizer, which reports a heap-buffer-overflow read on a non null-terminated view of three spaces. Swapping the two operands so the bounds check runs first closes the read and leaves the trimming behavior unchanged. I added a regression test in gtest_ports that fails under ASan before the change and passes after.