### PR TITLE
fix undefined float-to-integer cast at the numeric limit boundary

### DIFF
--- a/include/behaviortree_cpp/utils/convert_impl.hpp
+++ b/include/behaviortree_cpp/utils/convert_impl.hpp
@@ -114,8 +114,15 @@ inline void checkTruncation(const From& from)
   // Handle floating point to integer
   else if constexpr(std::is_floating_point_v<From> && std::is_integral_v<To>)
   {
-    if(from > static_cast<From>(std::numeric_limits<To>::max()) ||
-       from < static_cast<From>(std::numeric_limits<To>::lowest()) ||
+    // static_cast<From>(To::max) rounds up to an out-of-range value when To has
+    // more significant bits than From's mantissa (e.g. double -> int64_t). In
+    // that case a plain `>` lets the rounded boundary through and the cast to To
+    // below overflows, so use a half-open upper bound to reject it first.
+    constexpr bool max_rounds_up =
+        std::numeric_limits<To>::digits > std::numeric_limits<From>::digits;
+    const From max_limit = static_cast<From>(std::numeric_limits<To>::max());
+    const bool over = max_rounds_up ? (from >= max_limit) : (from > max_limit);
+    if(over || from < static_cast<From>(std::numeric_limits<To>::lowest()) ||
        from != std::nearbyint(from))
     {
       throw std::runtime_error("Invalid floating point to integer conversion");

--- a/include/behaviortree_cpp/utils/safe_any.hpp
+++ b/include/behaviortree_cpp/utils/safe_any.hpp
@@ -259,8 +259,16 @@ inline bool ValidCast(const SRC& val)
     // Handle conversion to integral
     else if constexpr(std::is_integral_v<TO>)
     {
-      if(val > static_cast<SRC>(std::numeric_limits<TO>::max()) ||
-         val < static_cast<SRC>(std::numeric_limits<TO>::lowest()))
+      // static_cast<SRC>(TO::max) rounds up to an out-of-range value when TO has
+      // more significant bits than a floating SRC's mantissa (e.g. double ->
+      // int64_t). A plain `>` would let that rounded boundary through and the
+      // cast to TO below overflows, so use a half-open upper bound in that case.
+      constexpr bool max_rounds_up =
+          std::is_floating_point_v<SRC> &&
+          std::numeric_limits<TO>::digits > std::numeric_limits<SRC>::digits;
+      const SRC max_limit = static_cast<SRC>(std::numeric_limits<TO>::max());
+      const bool over = max_rounds_up ? (val >= max_limit) : (val > max_limit);
+      if(over || val < static_cast<SRC>(std::numeric_limits<TO>::lowest()))
       {
         return false;
       }

--- a/tests/gtest_basic_types.cpp
+++ b/tests/gtest_basic_types.cpp
@@ -123,6 +123,31 @@ TEST(BasicTypes, ConvertFromString_Double)
   ASSERT_THROW((void)convertFromString<double>("not_a_number"), RuntimeError);
 }
 
+TEST(BasicTypes, DoubleToIntBoundary)
+{
+  // A double that lands exactly on 2^63 must be rejected before the cast, not
+  // static_cast to int64_t (which is out of range and undefined behavior).
+  // 2^63 = 9223372036854775808.0; INT64_MAX is 9223372036854775807.
+  const double two_pow_63 = 9223372036854775808.0;
+  EXPECT_ANY_THROW((void)BT::Any(two_pow_63).cast<int64_t>());
+
+  // 2^64 lands one past UINT64_MAX and must likewise be rejected.
+  const double two_pow_64 = 18446744073709551616.0;
+  EXPECT_ANY_THROW((void)BT::Any(two_pow_64).cast<uint64_t>());
+
+  // In-range integral doubles still convert cleanly.
+  const double in_range = 4611686018427387904.0;  // 2^62
+  EXPECT_EQ(BT::Any(in_range).cast<int64_t>(), int64_t(4611686018427387904LL));
+  EXPECT_EQ(BT::Any(1000.0).cast<int64_t>(), int64_t(1000));
+
+  // Same boundary reached through Blackboard::set, which routes the numeric
+  // safe-cast check (isCastingSafe/ValidCast) instead of Any::convert.
+  auto bb = BT::Blackboard::create();
+  bb->set("k", int64_t(1));  // lock the entry to int64_t
+  EXPECT_ANY_THROW(bb->set("k", two_pow_63));
+  EXPECT_NO_THROW(bb->set("k", in_range));
+}
+
 TEST(BasicTypes, ConvertFromString_Bool)
 {
   ASSERT_TRUE(convertFromString<bool>("true"));


### PR DESCRIPTION
The safe-cast helpers in convert_impl.hpp and safe_any.hpp gate a floating point to integer conversion with `from > static_cast<From>(numeric_limits<To>::max())`, and if that passes they static_cast the value to the integer type. The trouble is that when the target has more significant bits than the source mantissa, like double to int64_t or float to int32_t, `static_cast<From>(To::max)` rounds up to a value that is one past the real maximum: for int64_t it becomes 2^63, which is not representable in an int64_t. A double that lands exactly on 2^63 therefore slips past the `>` check and reaches `static_cast<int64_t>(2^63)`, which is signed-overflow undefined behavior. I hit it with UBSan while poking at numeric ports, since this path is reachable from a script bitwise operator on a double and from Blackboard::set on a port already locked to int64_t (isCastingSafe/ValidCast). The fix keeps the same limits but switches the upper bound to a half-open comparison when static_cast<From>(To::max) rounds up, decided at compile time from the digit counts, so the boundary value is rejected before the cast instead of after. Smaller targets like int32_t whose max is exactly representable keep the inclusive `>` and still accept their true maximum. I applied the same change at both sites and added a regression test that trips UBSan before the fix and passes after.