### PR TITLE
Fix package share path API for newer ament_index_cpp

### DIFF
--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -50,7 +50,12 @@
 #include <map>
 
 #ifdef USING_ROS2
+#include "ament_index_cpp/version.h"
+#if AMENT_INDEX_CPP_VERSION_GTE(1, 13, 2)
+#include <ament_index_cpp/get_package_share_path.hpp>
+#else
 #include <ament_index_cpp/get_package_share_directory.hpp>
+#endif
 #endif
 
 #include "behaviortree_cpp/blackboard.h"
@@ -397,8 +402,13 @@ void XMLParser::PImpl::loadDocImpl(XMLDocument* doc, bool add_includes)
       {
         std::string ros_pkg_path;  // NOLINT(misc-const-correctness)
 #if defined USING_ROS2
+#if AMENT_INDEX_CPP_VERSION_GTE(1, 13, 2)
+        ros_pkg_path = ament_index_cpp::get_package_share_path(ros_pkg_relative_path)
+                           .string();
+#else
         ros_pkg_path =
             ament_index_cpp::get_package_share_directory(ros_pkg_relative_path);
+#endif
 #else
         throw RuntimeError("Using attribute [ros_pkg] in <include>, but this library was "
                            "compiled without ROS support. Recompile the BehaviorTree.CPP "

--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -403,8 +403,9 @@ void XMLParser::PImpl::loadDocImpl(XMLDocument* doc, bool add_includes)
         std::string ros_pkg_path;  // NOLINT(misc-const-correctness)
 #if defined USING_ROS2
 #if AMENT_INDEX_CPP_VERSION_GTE(1, 13, 2)
-        ros_pkg_path = ament_index_cpp::get_package_share_path(ros_pkg_relative_path)
-                           .string();
+        std::filesystem::path pkg_share_dir =
+            ament_index_cpp::get_package_share_path(ros_pkg_relative_path);
+        ros_pkg_path = pkg_share_dir.string();
 #else
         ros_pkg_path =
             ament_index_cpp::get_package_share_directory(ros_pkg_relative_path);


### PR DESCRIPTION
This updates the XML include handling to use the newer package share path API when available, while preserving the older fallback for older ament_index_cpp versions.

Related: https://github.com/ament/ament_index/pull/120