### PR TITLE
Fixes WakeUp test flakiness

### DIFF
--- a/tests/gtest_wakeup.cpp
+++ b/tests/gtest_wakeup.cpp
@@ -41,13 +41,16 @@ TEST(WakeUp, BasicTest)
 
   using namespace std::chrono;
 
-  auto t1 = system_clock::now();
+  auto t1 = steady_clock::now();
   tree.tickOnce();
   tree.sleep(milliseconds(200));
-  auto t2 = system_clock::now();
+  auto t2 = steady_clock::now();
 
   auto dT = duration_cast<milliseconds>(t2 - t1).count();
   std::cout << "Woke up after msec: " << dT << std::endl;
 
-  ASSERT_LT(dT, 25);
+  // steady_clock is monotonic and immune to NTP/DST jumps.
+  // 100 ms gives headroom for scheduler jitter on loaded CI runners;
+  // the wake-up should fire well under that threshold.
+  ASSERT_LT(dT, 100);
 }


### PR DESCRIPTION
Addresses test flakiness in the `WakeUp` test by switching from `system_clock` to `steady_clock` for duration measurements.

- `system_clock` is susceptible to system time adjustments (e.g., NTP, DST), which can lead to unreliable duration calculations and intermittent test failures.
- `steady_clock` provides a monotonic clock, ensuring accurate and consistent elapsed time measurements, thereby improving test reliability.
- Adjusts the assertion threshold to 100ms to accommodate potential scheduler jitter on loaded CI runners, while still verifying prompt wake-up behavior.