### PR TITLE
fix use-after-free from dangling StringView in Blackboard::getKeys

### DIFF
--- a/include/behaviortree_cpp/blackboard.h
+++ b/include/behaviortree_cpp/blackboard.h
@@ -123,7 +123,7 @@ public:
 
   void debugMessage() const;
 
-  [[nodiscard]] std::vector<StringView> getKeys() const;
+  [[nodiscard]] std::vector<std::string> getKeys() const;
 
   [[deprecated("This command is unsafe. Consider using Backup/Restore instead")]] void
   clear();

--- a/src/blackboard.cpp
+++ b/src/blackboard.cpp
@@ -137,16 +137,14 @@ void Blackboard::debugMessage() const
   }
 }
 
-std::vector<StringView> Blackboard::getKeys() const
+std::vector<std::string> Blackboard::getKeys() const
 {
-  // Lock storage_mutex_ (shared) to prevent iterator invalidation and
-  // dangling StringView from concurrent modifications (BUG-6 fix).
+  // Return owning copies of the keys, made while holding the shared lock.
+  // Returning StringView into storage_ would dangle as soon as another thread
+  // erased an entry (Blackboard::unset / the UnsetBlackboard action) after the
+  // lock is released but before the caller reads the view.
   const std::shared_lock storage_lock(storage_mutex_);
-  if(storage_.empty())
-  {
-    return {};
-  }
-  std::vector<StringView> out;
+  std::vector<std::string> out;
   out.reserve(storage_.size());
   for(const auto& entry_it : storage_)
   {
@@ -337,9 +335,8 @@ std::shared_ptr<Blackboard::Entry> Blackboard::createEntryImpl(const std::string
 nlohmann::json ExportBlackboardToJSON(const Blackboard& blackboard)
 {
   nlohmann::json dest;
-  for(auto entry_name : blackboard.getKeys())
+  for(const auto& name : blackboard.getKeys())
   {
-    const std::string name(entry_name);
     if(auto any_ref = blackboard.getAnyLocked(name))
     {
       if(auto any_ptr = any_ref.get())

--- a/tests/gtest_blackboard_thread_safety.cpp
+++ b/tests/gtest_blackboard_thread_safety.cpp
@@ -335,3 +335,48 @@ TEST(BlackboardThreadSafety, GetKeysWhileModifying_Bug6)
 
   SUCCEED();
 }
+
+// BUG-6 (continued): getKeys() used to return StringView pointing into the
+// std::string keys of storage_. The shared lock is released when getKeys()
+// returns, so a concurrent erase (unset() / the UnsetBlackboard action) frees
+// the underlying key while the caller still reads the view. This is exactly
+// what ExportBlackboardToJSON does on the Groot2 server thread.
+// Under ASan/TSan this reports a heap-use-after-free before the fix.
+TEST(BlackboardThreadSafety, GetKeysReadWhileErasing_Bug6)
+{
+  auto bb = Blackboard::create();
+
+  constexpr int kIterations = 200000;
+  std::atomic<bool> stop{ false };
+
+  auto reader = [&]() {
+    while(!stop.load())
+    {
+      for(const auto& key : bb->getKeys())
+      {
+        // Read the key content after getKeys() released the lock.
+        volatile size_t s = std::string(key).size();
+        (void)s;
+      }
+    }
+  };
+
+  auto mutator = [&]() {
+    for(int i = 0; i < kIterations; i++)
+    {
+      const std::string key = "key_" + std::to_string(i % 64);
+      bb->set(key, i);
+      bb->unset(key);  // erase -> frees the map key's std::string
+    }
+    stop.store(true);
+  };
+
+  std::thread t1(reader);
+  std::thread t2(mutator);
+
+  t2.join();
+  stop.store(true);
+  t1.join();
+
+  SUCCEED();
+}


### PR DESCRIPTION
getKeys() hands back a std::vector<StringView> whose elements point into the std::string keys of the internal storage_ map. The shared lock added by the earlier BUG-6 fix is only held for the duration of getKeys() itself, so the returned views outlive it. ExportBlackboardToJSON walks those views after the lock is gone, and that path runs on the Groot2 publisher server thread in response to a BLACKBOARD request coming off the network. If the tree ticks an UnsetBlackboard node (or anything calling Blackboard::unset) in that window, unordered_map::erase destroys the key string and the StringView the exporter still holds now points at freed memory; constructing a std::string from it is a heap-use-after-free. I hit it while stress-testing concurrent key reads against unset, and ASan pins the read to the std::string copy in ExportBlackboardToJSON with the free coming from unset. The test file already had a note that getKeys() could dangle on erase, so this finishes that fix by returning owning std::string copies made under the lock instead of views into storage. Worth calling out that the return type changes from vector<StringView> to vector<std::string>, a small API change; all in-tree callers already copied into std::string anyway. The added regression test reads keys while another thread erases and reports the use-after-free under ASan before the change, clean after.