### PR TITLE
Pin ament install destinations to lib/include/bin (fixes #1175)

### DIFF
--- a/.github/workflows/ros2-lyrical.yaml
+++ b/.github/workflows/ros2-lyrical.yaml
@@ -1,0 +1,36 @@
+name: ros2-lyrical
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  industrial_ci:
+    strategy:
+      matrix:
+        env:
+          # TARGET_CMAKE_ARGS emulates the ROS build farm (bloom/debhelper),
+          # which configures with -DCMAKE_INSTALL_LIBDIR=lib/<multiarch>.
+          # AFTER_SCRIPT asserts that the library is still installed to
+          # $prefix/lib, as required by ament tooling (see issue #1175).
+          - ROS_DISTRO: lyrical
+            ROS_REPO: main
+            TARGET_CMAKE_ARGS: -DCMAKE_INSTALL_LIBDIR=lib/x86_64-linux-gnu
+            AFTER_SCRIPT: >-
+              lib=$(find "$BASEDIR/target_ws/install" -name libbehaviortree_cpp.so);
+              echo "libbehaviortree_cpp.so installed at: ${lib:-NOT FOUND}";
+              [[ "$lib" == */install/behaviortree_cpp/lib/libbehaviortree_cpp.so ]]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{matrix.env}}
+        with:
+            package-name: behaviortree_cpp

--- a/cmake/ament_build.cmake
+++ b/cmake/ament_build.cmake
@@ -15,6 +15,16 @@ set( BTCPP_EXTRA_LIBRARIES
 
 ament_export_dependencies(ament_index_cpp)
 
+# The ROS build farm (bloom/debhelper) configures with
+# -DCMAKE_INSTALL_LIBDIR=lib/<multiarch-triplet>, but ament tooling
+# (ament_export_libraries lookup, LD_LIBRARY_PATH environment hooks)
+# only supports libraries installed to $prefix/lib. These plain set()
+# calls intentionally shadow the GNUInstallDirs-based cache variables
+# defined in the top-level CMakeLists.txt (see issue #1175).
+set(BTCPP_LIB_DESTINATION lib)
+set(BTCPP_INCLUDE_DESTINATION include)
+set(BTCPP_BIN_DESTINATION bin)
+
 mark_as_advanced(
     BTCPP_EXTRA_LIBRARIES
     BTCPP_EXTRA_INCLUDE_DIRS


### PR DESCRIPTION
Fixes #1175

## Problem

Since #1152, the `BTCPP_*_DESTINATION` variables honor `CMAKE_INSTALL_LIBDIR` (GNUInstallDirs). The ROS build farm (bloom/debhelper) always configures with `-DCMAKE_INSTALL_LIBDIR=lib/x86_64-linux-gnu`, so the Lyrical/Rolling binaries started installing `libbehaviortree_cpp.so` to `/opt/ros/<distro>/lib/x86_64-linux-gnu/` instead of `/opt/ros/<distro>/lib/`.

That path breaks ROS in two independent ways:

- **Configure time**: the extras file generated by `ament_export_libraries()` hardcodes `find_library(... PATHS "${prefix}/../../../lib" NO_DEFAULT_PATH)`, so downstream `find_package(behaviortree_cpp)` fails (see ament/ament_cmake#630, e.g. the `auto_apms_behavior_tree_core` farm failure).
- **Runtime**: the ament environment hooks only put `$prefix/lib` on `LD_LIBRARY_PATH`, and `ldconfig` does not index `/opt` paths — so even with the ament fix, binaries would not find the library. This is why fixing ament alone is not sufficient and BT.CPP must pin the path itself.

## Solution

Plain `set()` calls in `cmake/ament_build.cmake` shadow the GNUInstallDirs-based cache variables whenever the ament build path is active, pinning the destinations to `lib`/`include`/`bin` regardless of what debhelper injects. Standalone (non-ROS) builds are untouched and keep the override behavior introduced for #1120.

Also adds a `ros2-lyrical` CI job (industrial_ci, same pattern as humble/jazzy) that emulates the build farm by passing `TARGET_CMAKE_ARGS: -DCMAKE_INSTALL_LIBDIR=lib/x86_64-linux-gnu`, with an `AFTER_SCRIPT` asserting the library lands in `install/behaviortree_cpp/lib/` — a permanent regression test for this issue.

## Verified (locally against /opt/ros/lyrical)

| Scenario | Result |
|---|---|
| ament + `-DCMAKE_INSTALL_LIBDIR=lib/x86_64-linux-gnu` (farm emulation) | installs to `lib` ✅ |
| staging `cmake --install` layout | `lib/libbehaviortree_cpp.so`, no multiarch dir ✅ |
| full test suite (ament build) | 100% passed ✅ |
| non-ament + `-DCMAKE_INSTALL_LIBDIR=lib/x86_64-linux-gnu` (#1120 feature) | `lib/x86_64-linux-gnu` ✅ |
| non-ament + `-DBTCPP_LIB_DESTINATION=custom/lib` | `custom/lib` ✅ |

## API / ABI

Build-system change only; no API or ABI impact. Restores the pre-4.9.1 install layout for ROS binaries — needs a 4.9.2 patch release + bloom re-release for the affected distros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)