### PR TITLE
reject trailing characters in SwitchNode numeric comparison

### DIFF
--- a/src/controls/switch_node.cpp
+++ b/src/controls/switch_node.cpp
@@ -39,13 +39,15 @@ bool CheckStringEquality(const std::string& v1, const std::string& v2,
       }
     }
 #if __cpp_lib_to_chars >= 201611L
-    auto [ptr, ec] = std::from_chars(str.data(), str.data() + str.size(), result);
-    return (ec == std::errc());
+    const char* end = str.data() + str.size();
+    auto [ptr, ec] = std::from_chars(str.data(), end, result);
+    return ec == std::errc() && ptr == end;
 #else
     try
     {
-      result = std::stoi(str);
-      return true;
+      std::size_t pos = 0;
+      result = std::stoi(str, &pos);
+      return pos == str.size();
     }
     catch(...)
     {
@@ -60,15 +62,26 @@ bool CheckStringEquality(const std::string& v1, const std::string& v2,
     return true;
   }
   // compare as real numbers next
-  auto ToReal = [](const std::string& str, auto& result) -> bool {
+  auto ToReal = [enums](const std::string& str, auto& result) -> bool {
+    if(enums)
+    {
+      auto it = enums->find(str);
+      if(it != enums->end())
+      {
+        result = it->second;
+        return true;
+      }
+    }
 #if __cpp_lib_to_chars >= 201611L
-    auto [ptr, ec] = std::from_chars(str.data(), str.data() + str.size(), result);
-    return (ec == std::errc());
+    const char* end = str.data() + str.size();
+    auto [ptr, ec] = std::from_chars(str.data(), end, result);
+    return ec == std::errc() && ptr == end;
 #else
     try
     {
-      result = std::stod(str);
-      return true;
+      std::size_t pos = 0;
+      result = std::stod(str, &pos);
+      return pos == str.size();
     }
     catch(...)
     {

--- a/tests/gtest_switch.cpp
+++ b/tests/gtest_switch.cpp
@@ -3,6 +3,7 @@
 
 #include "behaviortree_cpp/behavior_tree.h"
 #include "behaviortree_cpp/bt_factory.h"
+#include "behaviortree_cpp/controls/switch_node.h"
 #include "behaviortree_cpp/tree_node.h"
 
 #include <gtest/gtest.h>
@@ -244,4 +245,22 @@ TEST_F(SwitchTest, ActionFailure)
   ASSERT_EQ(NodeStatus::IDLE, action_1.status());
   ASSERT_EQ(NodeStatus::IDLE, action_42.status());
   ASSERT_EQ(NodeStatus::IDLE, action_def.status());
+}
+
+TEST(SwitchStringEquality, RejectsTrailingCharacters)
+{
+  using BT::details::CheckStringEquality;
+
+  // legitimate matches must keep working
+  EXPECT_TRUE(CheckStringEquality("5", "5", nullptr));
+  EXPECT_TRUE(CheckStringEquality("5", "5.0", nullptr));
+  EXPECT_TRUE(CheckStringEquality("42", "42", nullptr));
+  EXPECT_TRUE(CheckStringEquality("-7", "-7", nullptr));
+
+  // a selector with trailing bytes must not match a numeric case
+  EXPECT_FALSE(CheckStringEquality("5abc", "5", nullptr));
+  EXPECT_FALSE(CheckStringEquality("42xxxx", "42", nullptr));
+  EXPECT_FALSE(CheckStringEquality("1.0junk", "1.0", nullptr));
+  EXPECT_FALSE(CheckStringEquality("5 ", "5", nullptr));
+  EXPECT_FALSE(CheckStringEquality("none", "1", nullptr));
 }


### PR DESCRIPTION
SwitchNode picks a child by comparing its `variable` against each `case_N` with CheckStringEquality, which falls back from a string compare to an integer compare and then a real compare. The `variable` is a blackboard entry, so in practice it often carries a value that came from outside the tree. The integer and real fallbacks call std::from_chars (and std::stoi/std::stod on toolchains without the floating-point from_chars) but never check that the whole string was consumed, so `5abc`, `42xxxx`, and even `5 ` parse as their leading number and compare equal to case `5`, `42`, and `5`. That routes a selector with trailing bytes to a case it does not actually equal, which is easy to slip past a check that only looked at the string form. I ran into it on a switch whose selector came from a message field. The fix requires full consumption (ptr == end, or pos == size on the stoi/stod path) at all four numeric parses; I also let the real comparison resolve scripting enums the way the integer one already does, so an enum name still matches the double a script stores for it. String equality and legitimate numeric matches like `5` versus `5.0` are unchanged.
