### PR TITLE
validate backup size in BlackboardRestore

### DIFF
--- a/src/bt_factory.cpp
+++ b/src/bt_factory.cpp
@@ -773,7 +773,12 @@ NodeStatus Tree::tickRoot(TickOption opt, std::chrono::milliseconds sleep_time)
 
 void BlackboardRestore(const std::vector<Blackboard::Ptr>& backup, Tree& tree)
 {
-  assert(backup.size() == tree.subtrees.size());
+  if(backup.size() != tree.subtrees.size())
+  {
+    throw RuntimeError("BlackboardRestore: the backup contains ",
+                       std::to_string(backup.size()), " blackboards, but the tree has ",
+                       std::to_string(tree.subtrees.size()), " subtrees");
+  }
   for(size_t i = 0; i < tree.subtrees.size(); i++)
   {
     backup[i]->cloneInto(*(tree.subtrees[i]->blackboard));

--- a/tests/gtest_blackboard.cpp
+++ b/tests/gtest_blackboard.cpp
@@ -542,6 +542,47 @@ TEST(BlackboardTest, BlackboardBackup)
   ASSERT_EQ(status, BT::NodeStatus::SUCCESS);
 }
 
+TEST(BlackboardTest, BlackboardRestoreSizeMismatch)
+{
+  BT::BehaviorTreeFactory factory;
+
+  const std::string one_subtree = R"(
+  <root BTCPP_format="4" main_tree_to_execute="SmallTree">
+    <BehaviorTree ID="SmallTree">
+      <AlwaysSuccess />
+    </BehaviorTree>
+  </root> )";
+
+  const std::string four_subtrees = R"(
+  <root BTCPP_format="4" main_tree_to_execute="BigTree">
+    <BehaviorTree ID="MySubtree">
+      <AlwaysSuccess />
+    </BehaviorTree>
+    <BehaviorTree ID="BigTree">
+      <Sequence>
+        <SubTree ID="MySubtree" />
+        <SubTree ID="MySubtree" name="second" />
+        <SubTree ID="MySubtree" name="third" />
+      </Sequence>
+    </BehaviorTree>
+  </root> )";
+
+  auto small_tree = factory.createTreeFromText(one_subtree);
+  const auto bb_backup = BlackboardBackup(small_tree);
+  ASSERT_EQ(bb_backup.size(), 1u);
+
+  auto big_tree = factory.createTreeFromText(four_subtrees);
+  ASSERT_EQ(big_tree.subtrees.size(), 4u);
+
+  // The backup is shorter than the number of subtrees: reject it instead of
+  // indexing past the end of the vector.
+  ASSERT_THROW(BlackboardRestore(bb_backup, big_tree), BT::RuntimeError);
+
+  // A backup taken from the same tree must still be accepted.
+  const auto big_backup = BlackboardBackup(big_tree);
+  ASSERT_NO_THROW(BlackboardRestore(big_backup, big_tree));
+}
+
 TEST(BlackboardTest, RootBlackboard)
 {
   BT::BehaviorTreeFactory factory;


### PR DESCRIPTION
BlackboardBackup and BlackboardRestore are meant to be used as a pair, but the restore side drives its loop with tree.subtrees.size() while indexing the backup vector the caller passed in. The only thing tying those two sizes together is an assert, and since CMakeLists.txt forces a Release build when no build type is given, NDEBUG is set in the default and ROS builds and that check is gone. Both sizes are XML-determined, since a tree contributes one blackboard per subtree plus one for the root, so restoring into a tree that was rebuilt from different XML than the backup came from walks off the end of the vector: ASan reports a heap-buffer-overflow read at bt_factory.cpp:779, and cloneInto is then called through the stale shared_ptr that read produced. I ran into it while looking at the rewind pattern from t17_blackboard_backup, where the backup and the tree are not necessarily created together. ImportTreeFromJSON right below already validates the same relationship and throws, so I made BlackboardRestore do the same instead of leaving the guard to a caller. The new test builds a one-subtree backup, restores it into a four-subtree tree, and checks that the matching case still works.