### PR TITLE
clamp snprintf result before fwrite in mtr_flush_with_state

### DIFF
--- a/3rdparty/minitrace/minitrace.cpp
+++ b/3rdparty/minitrace/minitrace.cpp
@@ -353,6 +353,14 @@ void mtr_flush_with_state(int is_last) {
 		len = snprintf(linebuf, ARRAY_SIZE(linebuf), "%s{\"cat\":\"%s\",\"pid\":%i,\"tid\":%i,\"ts\":%" PRId64 ",\"ph\":\"%c\",\"name\":\"%s\",\"args\":{%s}%s}",
 				first_line ? "" : ",\n",
 				cat, raw->pid, raw->tid, raw->ts - time_offset, raw->ph, raw->name, arg_buf, id_buf);
+		// snprintf returns the length the line would have needed, not what it
+		// wrote, and a negative value on error, so clamp before using it as a
+		// write length.
+		if (len < 0) {
+			len = 0;
+		} else if ((size_t)len >= sizeof(linebuf)) {
+			len = (int)sizeof(linebuf) - 1;
+		}
 		fwrite(linebuf, 1, len, f);
 		first_line = 0;
 

--- a/tests/gtest_loggers.cpp
+++ b/tests/gtest_loggers.cpp
@@ -261,6 +261,33 @@ TEST_F(LoggerTest, MinitraceLogger_TransitionTypes)
   ASSERT_TRUE(std::filesystem::exists(filepath));
 }
 
+TEST_F(LoggerTest, MinitraceLogger_LongNodeName)
+{
+  // The node name goes into a 1024 byte line buffer. A name long enough to
+  // overflow it used to be written out with snprintf's would-be length, which
+  // reads past the buffer and copies stack bytes into the trace file.
+  const std::string long_name(1000, 'A');
+  const std::string xml_text = R"(
+    <root BTCPP_format="4">
+       <BehaviorTree>
+          <AlwaysSuccess name=")" +
+                               long_name + R"("/>
+       </BehaviorTree>
+    </root>)";
+
+  auto tree = factory.createTreeFromText(xml_text);
+  std::string filepath = test_dir + "/trace_long_name.json";
+
+  {
+    MinitraceLogger logger(tree, filepath.c_str());
+    tree.tickWhileRunning();
+    logger.flush();
+  }
+
+  ASSERT_TRUE(std::filesystem::exists(filepath));
+  ASSERT_LT(std::filesystem::file_size(filepath), 4096u);
+}
+
 // ============ SqliteLogger tests ============
 
 TEST_F(LoggerTest, SqliteLogger_Creation_db3)


### PR DESCRIPTION
MinitraceLogger passes node.name().c_str() to minitrace as the event name, and mtr_flush_with_state formats each event into a 1024 byte stack buffer before writing it out. The length handed to fwrite is snprintf's return value, which is the size the line would have needed rather than the size it actually wrote, so any event that overflows the buffer makes fwrite read past the end of linebuf. Node names come from the name attribute in the tree XML and nothing bounds their length, and mtr_flush() runs on every status transition, so a name of about a thousand characters is enough to reach it. The bytes read past the buffer are adjacent stack memory and they land verbatim in the trace file. I hit it under AddressSanitizer while looking at the logger tests: it reports a stack-buffer-overflow read of 1081 bytes out of the 1024 byte buffer at minitrace.cpp:356. Clamping len to what snprintf actually produced closes it, and treating a negative return as nothing-to-write also covers the MSVC _snprintf case where truncation reports -1 and fwrite would be called with (size_t)-1. I checked the rest of the tree for the same shape and this is the only place an snprintf return value is used as a length; the test added to gtest_loggers fails under ASan before the change and passes after.