### PR TITLE
preserve integer width in JsonExporter::fromJson

### DIFF
--- a/src/json_export.cpp
+++ b/src/json_export.cpp
@@ -1,5 +1,7 @@
 #include "behaviortree_cpp/json_export.h"
 
+#include <limits>
+
 namespace BT
 {
 
@@ -72,9 +74,27 @@ JsonExporter::ExpectedEntry JsonExporter::fromJson(const nlohmann::json& source)
     return Entry{ BT::Any(source.get<std::string>()),
                   BT::TypeInfo::Create<std::string>() };
   }
+  // get<int>() silently wraps any value outside the int range, so keep the
+  // width when the number doesn't fit. This lets an int64_t/uint64_t entry
+  // survive an export/import round-trip instead of coming back truncated.
+  if(source.is_number_unsigned())
+  {
+    const uint64_t value = source.get<uint64_t>();
+    if(value <= static_cast<uint64_t>(std::numeric_limits<int>::max()))
+    {
+      return Entry{ BT::Any(static_cast<int>(value)), BT::TypeInfo::Create<int>() };
+    }
+    return Entry{ BT::Any(value), BT::TypeInfo::Create<uint64_t>() };
+  }
   if(source.is_number_integer())
   {
-    return Entry{ BT::Any(source.get<int>()), BT::TypeInfo::Create<int>() };
+    const int64_t value = source.get<int64_t>();
+    if(value >= static_cast<int64_t>(std::numeric_limits<int>::min()) &&
+       value <= static_cast<int64_t>(std::numeric_limits<int>::max()))
+    {
+      return Entry{ BT::Any(static_cast<int>(value)), BT::TypeInfo::Create<int>() };
+    }
+    return Entry{ BT::Any(value), BT::TypeInfo::Create<int64_t>() };
   }
   if(source.is_number_float())
   {

--- a/tests/gtest_json.cpp
+++ b/tests/gtest_json.cpp
@@ -210,6 +210,42 @@ TEST_F(JsonTest, BlackboardInOut)
   ASSERT_EQ(vect_out.z, 3.3);
 }
 
+TEST_F(JsonTest, LargeIntegerPreserved)
+{
+  BT::JsonExporter& exporter = BT::JsonExporter::get();
+
+  // Values outside the int32 range used to be silently wrapped by get<int>().
+  {
+    auto json = nlohmann::json::parse(R"({"a": 2147483648, "b": 5000000000,
+                                          "c": 4294967296})");
+    auto bb = BT::Blackboard::create();
+    ImportBlackboardFromJSON(json, *bb);
+    ASSERT_EQ(bb->get<int64_t>("a"), 2147483648LL);
+    ASSERT_EQ(bb->get<int64_t>("b"), 5000000000LL);
+    ASSERT_EQ(bb->get<int64_t>("c"), 4294967296LL);
+  }
+  // Negative values below the int32 minimum are preserved too.
+  {
+    auto res = exporter.fromJson(nlohmann::json(int64_t(-5000000000LL)));
+    ASSERT_TRUE(res) << res.error();
+    ASSERT_EQ(res->first.cast<int64_t>(), -5000000000LL);
+  }
+  // Values that fit keep the int type, unchanged from before.
+  {
+    auto res = exporter.fromJson(nlohmann::json(100));
+    ASSERT_TRUE(res) << res.error();
+    ASSERT_EQ(res->first.cast<int>(), 100);
+  }
+  // An int64_t entry survives an Export/Import round-trip.
+  {
+    auto bb_in = BT::Blackboard::create();
+    bb_in->set("big", int64_t(5000000000LL));
+    auto bb_out = BT::Blackboard::create();
+    ImportBlackboardFromJSON(ExportBlackboardToJSON(*bb_in), *bb_out);
+    ASSERT_EQ(bb_out->get<int64_t>("big"), 5000000000LL);
+  }
+}
+
 TEST_F(JsonTest, VectorInteger)
 {
   BT::JsonExporter& exporter = BT::JsonExporter::get();


### PR DESCRIPTION
ExportBlackboardToJSON writes int64_t and uint64_t entries out at full width, but fromJson read every JSON integer back with nlohmann's get<int>(), which is just a static_cast<int> of the stored 64-bit value with no range check. Anything outside the int32 range wraps silently, so a saved int64_t of 5000000000 comes back as 705032704 and 4294967296 comes back as 0, and the same happens to any value fed through ImportBlackboardFromJSON or ImportTreeFromJSON when restoring tree state. I hit it doing an export/import round-trip and noticing the restored counter no longer matched. The fix keeps the width during import: values that fit in int stay int, larger magnitudes stay uint64_t or int64_t to match what toJson already emits. Small integers are unaffected, so the common case behaves exactly as before. Added a regression test that imports the out-of-range values and checks the round-trip.