### PR TITLE
fix @ root remapping in Blackboard::createEntryImpl

### DIFF
--- a/src/blackboard.cpp
+++ b/src/blackboard.cpp
@@ -282,6 +282,15 @@ Blackboard::Ptr Blackboard::parent()
 std::shared_ptr<Blackboard::Entry> Blackboard::createEntryImpl(const std::string& key,
                                                                const TypeInfo& info)
 {
+  // special syntax: "@" always refers to the root blackboard, the same
+  // redirection getEntry() applies. Without it, a key remapped to a root
+  // entry (port="{@foo}") is created here as a literal "@foo" entry that
+  // getEntry() then strips to "foo" and can never find again.
+  if(StartWith(key, '@'))
+  {
+    return rootBlackboard()->createEntryImpl(key.substr(1, key.size() - 1), info);
+  }
+
   const std::unique_lock storage_lock(storage_mutex_);
   // This function might be called recursively, when we do remapping, because we move
   // to the top scope to find already existing  entries

--- a/tests/gtest_blackboard.cpp
+++ b/tests/gtest_blackboard.cpp
@@ -636,6 +636,29 @@ TEST(BlackboardTest, RootBlackboard)
   ASSERT_EQ(4, tree.rootBlackboard()->get<int>("var5"));
 }
 
+TEST(BlackboardTest, RemapToRootBlackboard)
+{
+  // A subtree port remapped to a root key (XML: param="{@shared}") must resolve
+  // to the "shared" entry in the root blackboard. createEntryImpl used to create
+  // it as a literal "@shared" entry instead, so getEntry("param") -- which strips
+  // the '@' and looks up "shared" in the root -- never found it again. That made
+  // ImportBlackboardFromJSON dereference a null entry, and set()/get() disagree.
+  auto root = Blackboard::create();
+  auto child = Blackboard::create(root);
+  child->addSubtreeRemapping("param", "@shared");
+
+  nlohmann::json js;
+  js["param"] = 42;
+  ASSERT_NO_THROW(ImportBlackboardFromJSON(js, *child));
+
+  ASSERT_EQ(42, child->get<int>("param"));
+  ASSERT_EQ(42, root->get<int>("shared"));
+
+  child->set("param", 7);
+  ASSERT_EQ(7, child->get<int>("param"));
+  ASSERT_EQ(7, root->get<int>("shared"));
+}
+
 TEST(BlackboardTest, TimestampedInterface)
 {
   auto bb = BT::Blackboard::create();


### PR DESCRIPTION
A subtree port that remaps to a root blackboard key, written as port="{@foo}" in the XML, is stored as the remapping param -> @foo. When that entry is first created, createEntryImpl walks the remapping up to the parent but never applies the @ redirection that getEntry, set, and createEntry all use, so it lands as a literal @foo entry in the root storage. getEntry then strips the @ and looks up foo in the root, which never matches, so the two disagree about where the entry actually lives. I ran into it through ImportBlackboardFromJSON, the public restore path behind ImportTreeFromJSON: it looks the key up, misses, creates it, looks again, still gets null, and then locks entry_mutex on that null pointer for a segfault. The same split loses data silently as well, since set("param") writes into @foo while a reader gets foo from the root. Moving the @ handling getEntry already has into createEntryImpl keeps creation and lookup in agreement, and the added test crashes before the change and passes after.