### PR TITLE
validate substituted node type in instantiateTreeNode

### DIFF
--- a/src/bt_factory.cpp
+++ b/src/bt_factory.cpp
@@ -365,6 +365,28 @@ std::unique_ptr<TreeNode> BehaviorTreeFactory::instantiateTreeNode(
     }
   }
 
+  // A substitution rule must not turn a node into a structurally incompatible
+  // type. The XML was validated (children count, mandatory ID) against the
+  // original node type, so replacing a leaf with a SubTree, Decorator or
+  // Control leaves the builder with a node whose child or "ID" attribute the
+  // XML never supplied. That later dereferences a null child pointer or builds
+  // a std::string from a null Attribute("ID"). Allow same-type swaps and swaps
+  // to a leaf (the common "replace with a mock action" case, including the
+  // SubTree -> TestNode substitution used for mocking).
+  if(substituted)
+  {
+    const NodeType original_type = it_manifest->second.type;
+    const NodeType new_type = node->type();
+    if(new_type != original_type && new_type != NodeType::ACTION &&
+       new_type != NodeType::CONDITION)
+    {
+      throw RuntimeError("Substitution of node [", ID, "] of type [",
+                         toStr(original_type), "] with a node of type [", toStr(new_type),
+                         "] is not allowed: a substitution may only keep the same "
+                         "type or replace the node with a leaf (Action/Condition)");
+    }
+  }
+
   // No substitution rule applied: default behavior
   if(!substituted)
   {

--- a/tests/gtest_substitution.cpp
+++ b/tests/gtest_substitution.cpp
@@ -546,3 +546,46 @@ TEST(Substitution, StringSubstitutionRegistrationID_Issue930)
   // The substituted node should still work correctly
   ASSERT_EQ(tree.tickWhileRunning(), NodeStatus::SUCCESS);
 }
+
+// Regression test: a substitution rule must not turn a node into a
+// structurally incompatible type. The XML for a compact leaf (<AlwaysSuccess/>)
+// carries no "ID" attribute and no children, so replacing it with a SubTree
+// (which reads element->Attribute("ID")) or a Decorator (which needs a child)
+// used to segfault at tree construction / first tick. It must now throw.
+TEST(Substitution, IncompatibleTypeSubstitutionThrows)
+{
+  static const char* xml_text = R"(
+  <root BTCPP_format="4">
+    <BehaviorTree ID="MainTree">
+      <AlwaysSuccess name="action_A"/>
+    </BehaviorTree>
+  </root>
+  )";
+
+  // leaf -> SubTree: element has no ID attribute
+  {
+    BehaviorTreeFactory factory;
+    factory.registerBehaviorTreeFromText(xml_text);
+    factory.addSubstitutionRule("action_A", "SubTree");
+    EXPECT_THROW(factory.createTree("MainTree"), RuntimeError);
+  }
+
+  // leaf -> Decorator: element has no child
+  {
+    BehaviorTreeFactory factory;
+    factory.registerBehaviorTreeFromText(xml_text);
+    factory.addSubstitutionRule("action_A", "Inverter");
+    EXPECT_THROW(factory.createTree("MainTree"), RuntimeError);
+  }
+
+  // leaf -> leaf stays valid (the common mock case)
+  {
+    BehaviorTreeFactory factory;
+    factory.registerBehaviorTreeFromText(xml_text);
+    factory.registerSimpleAction("MyMock", [](TreeNode&) { return NodeStatus::SUCCESS; });
+    factory.addSubstitutionRule("action_A", "MyMock");
+    Tree tree;
+    ASSERT_NO_THROW(tree = factory.createTree("MainTree"));
+    EXPECT_EQ(tree.tickWhileRunning(), NodeStatus::SUCCESS);
+  }
+}


### PR DESCRIPTION
Substitution rules replace a node by ID, but `instantiateTreeNode` never checks that the replacement has a compatible node type. The XML around the node was validated for its ORIGINAL type (mandatory ID, child count), so a compact leaf swapped for a structural node is mishandled at build time:

    <AlwaysSuccess name="action_A"/>  +  addSubstitutionRule("action_A", "SubTree")
    => Segmentation fault (exit 139)

The crash is `std::string(element->Attribute("ID"))` at xml_parsing.cpp:1095. A compact `<AlwaysSuccess/>` carries no ID, so `Attribute("ID")` is null and the string constructor calls `strlen(nullptr)`. The same setup with `"Inverter"` leaves the decorator `child_node_` null and segfaults on the first tick instead. Both are reachable from an untrusted `SubstitutionRules` JSON plus ordinary XML, before any node runs.

The fix rejects a substitution whose resulting type differs from the original unless the replacement is a leaf (Action or Condition). That keeps the supported cases working, same-type swaps and the `SubTree` to `TestNode` mocking path from #934, and turns both crashes into a clear `RuntimeError`. Added a regression test that segfaults before the change and passes after.